### PR TITLE
Added API explanation

### DIFF
--- a/learning-ojs/en/user-accounts.md
+++ b/learning-ojs/en/user-accounts.md
@@ -135,6 +135,8 @@ To view and edit your profile, log in and click your Username link from the uppe
 
 From here, by choosing the different tabs, you can update your personal details, contact information, change your roles, add a personal image \(which some journals may publish along with your article or on a list of editors\), determine your notification settings, or update your password.
 
+The API tab on the user profile allows a user to use OJS’s REST API to interact with external applications.  However, most users will not use the API and can ignore this tab.
+
 ## Resetting your Password
 
 You can reset your password by:


### PR DESCRIPTION
One of our hosted users expressed confusion about the API tab on the User Profile and Michael suggested we add something to the documentation explaining what this is, to refer people there in the future (until this feature is hidden for most users per https://github.com/pkp/pkp-lib/issues/3635). Do you think this explanation is sufficient and accurate?