### PR TITLE
Made heading consistent with TOC

### DIFF
--- a/learning-ojs/en/introduction.md
+++ b/learning-ojs/en/introduction.md
@@ -31,7 +31,7 @@ OJS includes the following features:
 8. Complete context-sensitive online Help support  
 9. Multilingual support
 
-## What's New in OJS 3.1
+## What's New in OJS 3
 
 OJS 3.1 builds on the changes introduced with OJS 3, and is significantly different than its predecessor, OJS 2. It includes enhancements and new features developed from community feedback, extensive usability testing, and new software design capabilities.
 

--- a/learning-ojs/en/introduction.md
+++ b/learning-ojs/en/introduction.md
@@ -33,7 +33,7 @@ OJS includes the following features:
 
 ## What's New in OJS 3
 
-OJS 3.1 builds on the changes introduced with OJS 3, and is significantly different than its predecessor, OJS 2. It includes enhancements and new features developed from community feedback, extensive usability testing, and new software design capabilities.
+OJS 3 is significantly different than its predecessor, OJS 2. It includes enhancements and new features developed from community feedback, extensive usability testing, and new software design capabilities.
 
 ## Reader Interface
 


### PR DESCRIPTION
A user pointed out the TOC heading said "What's new in OJS 3" and the heading in the text said "What's new in OJS 3.1."  I changed it to 3.