### PR TITLE
Clarified wording in Inform the Editor

### DIFF
--- a/learning-ojs/en/authoring.md
+++ b/learning-ojs/en/authoring.md
@@ -162,7 +162,7 @@ Your revised file is now visible in the Revisions panel.
 
 ### Inform the Editor
 
-Your next step is to inform the editor that the revised file is now available. To do so, go to the Review Discussion panel.
+The editor will receive a notification about the new file(s) being uploaded. Additionally you can inform the editor via the Review Discussion panel as explained below.
 
 ![](./assets/learning-ojs-3-auth-responding-discussion.png)
 


### PR DESCRIPTION
Clarified that sending a message to the Editor about the new files can be done as an optional/additional step, in addition to system notification