### PR TITLE
remove pdf icon from GDPR guide in OMP section

### DIFF
--- a/_includes/cards/omp3/gdpr.md
+++ b/_includes/cards/omp3/gdpr.md
@@ -1,4 +1,4 @@
 
-### [<span class="far fa-file-pdf"></span> GDPR Guide](/gdpr/en)
+### [GDPR Guide](/gdpr/en)
 
 This guide provides advice for users of PKP applications on how to approach the EU General Data Protection Regulation (GDPR). [View Now](/gdpr/en)


### PR DESCRIPTION
missed this one in #148 