### PR TITLE
Amandastevens addthemes

### DIFF
--- a/pkp-theming-guide/en/SUMMARY.md
+++ b/pkp-theming-guide/en/SUMMARY.md
@@ -1,7 +1,7 @@
 # Summary
 
 * [Introduction](.)
-* [What is a theme?](what-is-a-theme.md)
+* [What Is a Theme?](what-is-a-theme.md)
    * [CSS/LESS](css-less.md)
    * [HTML/Smarty Templates](html-smarty.md)
    * [Theme Setup & Configuration](theme-setup.md)
@@ -13,5 +13,9 @@
 * [Themes](themes.md)
    * [Default Theme](theme-default.md)
    * [Bootstrap3 Theme](theme-bootstrap3.md)
+   * [Classic Theme](theme-classic.md)
+   * [Health Sciences Theme](theme-healthsciences.md)
+   * [Immersion Theme](theme-immersion.md)
+   * [Manuscript Theme](theme-manuscript.md)
 * Advanced Techniques
    * [Passing Data to Templates](advanced-custom-data.md)

--- a/pkp-theming-guide/en/theme-classic.md
+++ b/pkp-theming-guide/en/theme-classic.md
@@ -1,7 +1,9 @@
 # Classic Theme
 
-The Classic Theme should bring to mind classics and scholarship. It uses a serif typeface (Cardo) designed for “classicists, biblical scholars, medievalists, and linguists,” and was inspired by the work of Renaissance printer Aldus Manutius. [This OJS site](https://demo.publicknowledgeproject.org/ojs3/demo/index.php/classic) demonstrates the Classic theme.
+The Classic Theme should bring to mind classics and scholarship. It uses a serif typeface (Cardo) designed for “classicists, biblical scholars, medievalists, and linguists,” and was inspired by the work of Renaissance printer Aldus Manutius. 
+
+[This OJS site](https://demo.publicknowledgeproject.org/ojs3/demo/index.php/classic) demonstrates the Classic theme.
 
 Classic features a block-based layout for an issue’s table of contents, which makes great use of larger screens. But it also collapses into a clean, accessible view for smaller screens. The theme comes with an arresting yellow as the default primary colour to bring energy to a traditional style, but you can choose whatever color fits your brand. 
 
-Installation and configuration instructions are available in the theme plugin's [README file](https://github.com/pkp/classic/blob/master/README.md).
+Installation and configuration instructions are available in the theme plugin's [style guide](https://github.com/pkp/classic/blob/master/README.md).

--- a/pkp-theming-guide/en/theme-classic.md
+++ b/pkp-theming-guide/en/theme-classic.md
@@ -1,0 +1,7 @@
+# Classic Theme
+
+The Classic Theme should bring to mind classics and scholarship. It uses a serif typeface (Cardo) designed for “classicists, biblical scholars, medievalists, and linguists,” and was inspired by the work of Renaissance printer Aldus Manutius. [This OJS site](https://demo.publicknowledgeproject.org/ojs3/demo/index.php/classic) demonstrates the Classic theme.
+
+Classic features a block-based layout for an issue’s table of contents, which makes great use of larger screens. But it also collapses into a clean, accessible view for smaller screens. The theme comes with an arresting yellow as the default primary colour to bring energy to a traditional style, but you can choose whatever color fits your brand. 
+
+Installation and configuration instructions are available in the theme plugin's [README file](https://github.com/pkp/classic/blob/master/README.md).

--- a/pkp-theming-guide/en/theme-healthsciences.md
+++ b/pkp-theming-guide/en/theme-healthsciences.md
@@ -1,0 +1,5 @@
+# Health Sciences Theme
+
+The Health Sciences Theme is an official theme for OJS 3.1.1+ designed for health science journals or any journal that wants a clean, modern appearance. Using the contemporary and humanist typeface, Fira Sans, this theme was designed with cleanliness, simplicity and accessibility in mind. [This OJS site](https://demo.publicknowledgeproject.org/ojs3/demo/index.php/health-sciences) demonstrates the Health Sciences theme.
+
+Installation and configuration instructions are available in the theme plugin's [README file](https://github.com/pkp/healthSciences/blob/master/README.md).

--- a/pkp-theming-guide/en/theme-healthsciences.md
+++ b/pkp-theming-guide/en/theme-healthsciences.md
@@ -1,5 +1,7 @@
 # Health Sciences Theme
 
-The Health Sciences Theme is an official theme for OJS 3.1.1+ designed for health science journals or any journal that wants a clean, modern appearance. Using the contemporary and humanist typeface, Fira Sans, this theme was designed with cleanliness, simplicity and accessibility in mind. [This OJS site](https://demo.publicknowledgeproject.org/ojs3/demo/index.php/health-sciences) demonstrates the Health Sciences theme.
+The Health Sciences Theme is an official theme for OJS 3.1.1+ designed for health science journals or any journal that wants a clean, modern appearance. Using the contemporary and humanist typeface, Fira Sans, this theme was designed with cleanliness, simplicity and accessibility in mind. 
 
-Installation and configuration instructions are available in the theme plugin's [README file](https://github.com/pkp/healthSciences/blob/master/README.md).
+[This OJS site](https://demo.publicknowledgeproject.org/ojs3/demo/index.php/health-sciences) demonstrates the Health Sciences theme.
+
+Installation and configuration instructions are available in the theme's [style guide](https://github.com/pkp/healthSciences/blob/master/README.md).

--- a/pkp-theming-guide/en/theme-immersion.md
+++ b/pkp-theming-guide/en/theme-immersion.md
@@ -1,0 +1,9 @@
+# Immersion Theme
+
+Immersion emphasizes the reading experience and offers bold design options such as a full-width header image and per-section color choices. The serif typeface, Spectral, conveys a strong artistic personality and is paired with the crisp functionality of Roboto, a sans-serif typeface. 
+
+[This OJS site](https://demo.publicknowledgeproject.org/ojs3/demo/index.php/djit) demonstrates the Immersion theme.
+
+This theme allows you to display a full-width image in the header. When used appropriately, the image and color options can provide a striking aesthetic that will stand out from other journals. This effect may work best for arts and culture journals which want to present a more ambitious visual profile.
+
+Installation and configuration instructions are available in the theme's [style guide](https://github.com/pkp/immersion/blob/master/README.md).

--- a/pkp-theming-guide/en/theme-manuscript.md
+++ b/pkp-theming-guide/en/theme-manuscript.md
@@ -1,8 +1,10 @@
 # Manuscript Theme
 
-Manuscript is a clean, simple theme with a boxed layout that mimics a paper document. [This OJS site](https://demo.publicknowledgeproject.org/ojs3/demo/index.php/manuscript) demonstrates the Manuscript theme.
+Manuscript is a clean, simple theme with a boxed layout that mimics a paper document. 
+
+[This OJS site](https://demo.publicknowledgeproject.org/ojs3/demo/index.php/manuscript) demonstrates the Manuscript theme.
 
 The theme really shines when you configure your journal without a sidebar, benefiting from generous spacing that brings focus to the main content. But it looks great regardless of whether or not you use the sidebar. Just like the default theme, you can tailor the colours to match your journal’s branding.
 
-Installation and configuration instructions are available in the theme plugin's [README file](https://github.com/NateWr/defaultManuscript/blob/master/readme.md).
+Installation and configuration instructions are available in the theme's [style guide](https://github.com/NateWr/defaultManuscript/blob/master/readme.md).
 

--- a/pkp-theming-guide/en/theme-manuscript.md
+++ b/pkp-theming-guide/en/theme-manuscript.md
@@ -1,0 +1,8 @@
+# Manuscript Theme
+
+Manuscript is a clean, simple theme with a boxed layout that mimics a paper document. [This OJS site](https://demo.publicknowledgeproject.org/ojs3/demo/index.php/manuscript) demonstrates the Manuscript theme.
+
+The theme really shines when you configure your journal without a sidebar, benefiting from generous spacing that brings focus to the main content. But it looks great regardless of whether or not you use the sidebar. Just like the default theme, you can tailor the colours to match your journal’s branding.
+
+Installation and configuration instructions are available in the theme plugin's [README file](https://github.com/NateWr/defaultManuscript/blob/master/readme.md).
+

--- a/pkp-theming-guide/en/themes.md
+++ b/pkp-theming-guide/en/themes.md
@@ -1,4 +1,10 @@
 # Themes
 
+These pages include a description of each theme and links to a demonstration site and style guide.
+
 - [Default](theme-default.md) The default theme that ships with OJS 3.0+ and OMP 1.2+.
 - [Bootstrap3](theme-bootstrap3.md) A community-built theme that uses Bootstrap 3 HTML, CSS and JS.
+- [Classic](theme-classic.md)
+- [Health Sciences](theme-healthsciences.md)
+- [Immersion](theme-immersion.md)
+- [Manuscript](theme-manuscript.md)


### PR DESCRIPTION
I added the rest of the OJS 3 themes to the Themes chapter. In each theme sub-chapter I included a description of the theme, link to the demo site, and link to the README file/style guide. The README file can remain the main source of information about the theme so we don't have to keep 2 sources of information updated.