### PR TITLE
Fix header text running to two lines on large Mac screens

### DIFF
--- a/_sass/components/siteHeader.scss
+++ b/_sass/components/siteHeader.scss
@@ -50,7 +50,7 @@
 		display: inline-block;
 		position: relative;
 		left: auto;
-		max-width: 65%;
+		max-width: 75%;
 		padding-left: 2rem;
 		vertical-align: middle;
 


### PR DESCRIPTION
Addresses an alignment issue on large screens that only seems to happen on MacOS. I'm guessing that it is due to different font rendering and that this will solve it (but I don't have a MacOS machine to check).

<img width="1223" alt="screen_shot_2019-02-18_at_23 00 53" src="https://user-images.githubusercontent.com/2306629/53333978-52dc0180-38ef-11e9-933e-d5f013b09225.png">
