### PR TITLE
remove ojs 2 card and add to hero section

### DIFF
--- a/_data/index.yml
+++ b/_data/index.yml
@@ -3,7 +3,7 @@ quickLinksLabel: "Jump to:"
 apps:
   - path: ojs3
     title: Open Journal Systems 3
-    titleShort: OJS
+    titleShort: OJS 3
     includeInHero: true
     description: Our flagship software for open access journal publishing, used by more than 10,000 journals worldwide.
     cards:
@@ -16,12 +16,10 @@ apps:
       - path: pkp-school
       - path: crossref-ojs-manual
       - path: gdpr
-      - path: looking-for-ojs-2
-        isHighlighted: true
   - path: ojs2
     title: Open Journal Systems 2
     titleShort: OJS 2
-    includeInHero: false
+    includeInHero: true
     description: "Help guides for older versions of our journal management software. We recommend you [upgrade to OJS 3](#appojs3)."
     cards:
         - path: learning-ojs-2


### PR DESCRIPTION
Removes the 'looking for OJS 2 card' and adds an OJS 2 option to the hero area 'jump to...' section.