### PR TITLE
Added info re: counters on the dashboard for queues

### DIFF
--- a/learning-ojs/en/editorial-workflow.md
+++ b/learning-ojs/en/editorial-workflow.md
@@ -48,7 +48,7 @@ Users can also change their individual notification settings from their own prof
 
 ## Submission Dashboard
 
-When you log into your Dashboard, you can find active submissions either from your Tasks, or from one of the queues \(My Queue, Unassigned, All Active, and Archives\).
+When you log into your Dashboard, you can find active submissions either from your Tasks, or from one of the queues \(My Queue, Unassigned, All Active, and Archives\). The counter gives you an overview of how many total items are in each queue.
 
 ![](./assets/learning-ojs3.1-ed-dashboard-active.png)
 


### PR DESCRIPTION
I couldn't upload any screenshots to the /assets folder because upload has been disabled (or am I using the tool incorrectly?) Additionally, none of the journals in the ojs 3.2 test instance has much content at this time; should we wait to create new screenshots when there's more sample content available? Thanks, Emily