### PR TITLE
Footer "Contact" link

### DIFF
--- a/_data/site.yml
+++ b/_data/site.yml
@@ -23,4 +23,8 @@ navAbout:
   items:
     - "[Public Knowledge Project](https://pkp.sfu.ca)"
     - "[PKP&#124;Publishing Services](https://pkpservices.sfu.ca/)"
+navContact:
+  title: Contact
+  items:
+    - "[Contact Us](https://pkp.sfu.ca/documentation-feedback/)"
 toggleMenu: "Toggle Menu"

--- a/_includes/hub/footer.html
+++ b/_includes/hub/footer.html
@@ -25,5 +25,15 @@
 				{% endfor %}
 			</div>
 		{% endif %}
+		{% if site.data.site.navContact %}
+			<div class="siteFooter__nav">
+				<div class="siteFooter__navHeader">
+					{{ site.data.site.navContact.title }}
+				</div>
+				{% for nav in site.data.site.navContact.items %}
+					{{ nav | markdownify }}
+				{% endfor %}
+			</div>
+		{% endif %}
 	</div>
 </div>


### PR DESCRIPTION
Adds a contact link in the footer, which directs users to a form on the PKP site.

It may make sense to group the forums and the contact link under a heading called "Support", but I'm not sure what we should call the first column if we want to make that change. Maybe "Contributing"?

<img width="823" alt="Screen Shot 2020-05-28 at 5 04 47 PM" src="https://user-images.githubusercontent.com/6903515/83193678-7353c680-a105-11ea-9787-6bcc81672626.png">
