### PR TITLE
Fix "PKP website" link

### DIFF
--- a/upgrading-ojs-2-to-3/en/upgrade-planning.md
+++ b/upgrading-ojs-2-to-3/en/upgrade-planning.md
@@ -33,7 +33,7 @@ For additional resources outlining the new features in OJS 3 and upgrade-related
 
 ## Decide which version of OJS 3 to upgrade to
 
-Generally you should upgrade to the latest version of OJS. However, if the latest version is a new major release (e.g., OJS 3.1.0, OJS 3.2.0), you may want to wait until the next minor release is available (e.g., OJS 3.1.0-1; OJS 3.2.0-1) because usually a new major release has a few unexpected bugs that will be fixed in the first minor release that follows. Check the [https://pkp.sfu.ca/category/news/](PKP website) for news about releases when making this decision.
+Generally you should upgrade to the latest version of OJS. However, if the latest version is a new major release (e.g., OJS 3.1.0, OJS 3.2.0), you may want to wait until the next minor release is available (e.g., OJS 3.1.0-1; OJS 3.2.0-1) because usually a new major release has a few unexpected bugs that will be fixed in the first minor release that follows. Check the [PKP website](https://pkp.sfu.ca/category/news/) for news about releases when making this decision.
 
 ## Plan your upgrade
 


### PR DESCRIPTION
The link resulted in 404 on https://docs.pkp.sfu.ca/upgrading-ojs-2-to-3/en/PKP%20website, because the two parentheses in Markdown were flipped.