### PR TITLE
Fixing broken link to infographic

### DIFF
--- a/student-toolkit/en/getting-started.md
+++ b/student-toolkit/en/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-The infographic, [How to start an Open Access journal](http://hybridpublishing.org/files/2014/07/HOAJ-POSTER-final-web.pdf), outlines the things to consider when planning a new journal (see [appendix two](./appendix-2)). Similarly, Simon Fraser University has a similar [New Journal Checklist](https://www.lib.sfu.ca/help/publish/dp/new-journal-checklist). Take some time to view it or similar resources in these early planning stages.
+The infographic, [How to start an Open Access journal](http://projects.digital-cultures.net/hybrid-publishing-lab/files/2014/07/HOAJ-POSTER-final-web.pdf), outlines the things to consider when planning a new journal (see [appendix two](./appendix-2)). Similarly, Simon Fraser University has a similar [New Journal Checklist](https://www.lib.sfu.ca/help/publish/dp/new-journal-checklist). Take some time to view it or similar resources in these early planning stages.
 
 ## PKP School
 


### PR DESCRIPTION
The link to the How to Start an Open Access Journal infographic was broken, so I've replaced it with the up-to-date URL.