### PR TITLE
Issue 513

### DIFF
--- a/_layouts/book.html
+++ b/_layouts/book.html
@@ -4,7 +4,11 @@
 	<body {% if page.isBookIndex != true %} class="body--withSidebar"{% endif %}>
 		{% include book/header.html %}
 		<div class="book">
-			<a href="#sidebar" class="-screenReader">{{ site.data.site.skipToSummary }}</a>
+			{% if page.generateHeadingToc or page.isBookIndex != true %}
+				<a href="#sidebar" class="-screenReader">
+					{{ site.data.site.skipToSummary }}
+				</a>
+			{% endif %}
 			<div class="book__page">
 				<div class="book__content">
 					<div class="book__improve">

--- a/_layouts/book.html
+++ b/_layouts/book.html
@@ -4,7 +4,7 @@
 	<body {% if page.isBookIndex != true %} class="body--withSidebar"{% endif %}>
 		{% include book/header.html %}
 		<div class="book">
-			<a href="#summary" class="-screenReader">{{ site.data.site.skipToSummary }}</a>
+			<a href="#sidebar" class="-screenReader">{{ site.data.site.skipToSummary }}</a>
 			<div class="book__page">
 				<div class="book__content">
 					<div class="book__improve">


### PR DESCRIPTION
Changes the TOC skip link to point to `#sidebar` and only displays the skip link when there is a TOC. Resolves #513.