### PR TITLE
temporarily point to 3.1 learning ojs es version

### DIFF
--- a/learning-ojs/index.md
+++ b/learning-ojs/index.md
@@ -5,7 +5,7 @@ isBookIndex: true
 # Learning OJS 3.2: A Visual Guide to Open Journal Systems
 
 * [English](./en)
-* [Español](./es)
+* [Español (3.1)](3.1/es)
 * [Français](./fr)
 * [Suomi](./fi)
 * [العربية](./ar)


### PR DESCRIPTION
Temporarily point learning-ojs/es to the 3.1 version until the 3.2 translation is complete