### PR TITLE
Temporarily change Spanish link to 3.1 guide

### DIFF
--- a/_includes/cards/ojs3/learning-ojs-3.md
+++ b/_includes/cards/ojs3/learning-ojs-3.md
@@ -14,4 +14,4 @@ A visual, step-by-step guide to managing a journal with Open Journal Systems. [V
 
 ---
 
-<span class='fa fa-language'></span> Available in [العربية](/learning-ojs/ar/), [Español](/learning-ojs/es/), [Français](/learning-ojs/fr/), and [Suomi](/learning-ojs/fi/).
+<span class='fa fa-language'></span> Available in [العربية](/learning-ojs/ar/), [Español](/learning-ojs/3.1/es/), [Français](/learning-ojs/fr/), and [Suomi](/learning-ojs/fi/).


### PR DESCRIPTION
Temporarily changed Spanish link to 3.1 guide as per Amanda's suggestion while the update to the Spanish guide is pending. Alternatively it can be temporarily removed?