### PR TITLE
Fix broken link

### DIFF
--- a/student-toolkit/en/getting-started.md
+++ b/student-toolkit/en/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-The infographic, [How to start an Open Access journal](http://projects.digital-cultures.net/hybrid-publishing-lab/files/2014/07/HOAJ-POSTER-final-web.pdf), outlines the things to consider when planning a new journal (see [appendix two](./appendix-2)). Similarly, Simon Fraser University has a similar [New Journal Checklist](https://www.lib.sfu.ca/help/publish/dp/new-journal-checklist). Take some time to view it or similar resources in these early planning stages.
+The infographic, [How to start an Open Access journal (Appendix 2)](./appendix-2), outlines the things to consider when planning a new journal. Similarly, Simon Fraser University has a similar [New Journal Checklist](https://www.lib.sfu.ca/help/publish/dp/new-journal-checklist). Take some time to view it or similar resources in these early planning stages.
 
 ## PKP School
 


### PR DESCRIPTION
Link to "How to start an OA journal" PDF was broken. Replace with link to version in appendix.