### PR TITLE
Update PKP repository links to use main branch

### DIFF
--- a/admin-guide/en/data-import-and-export.md
+++ b/admin-guide/en/data-import-and-export.md
@@ -34,10 +34,10 @@ To use this plugin you will need the following:
 
 If you are importing data, first create the XML import file.  Here are links to sample XML import files and XML schemas:
 
-* Sample XML file for article metadata: [https://github.com/pkp/ojs/blob/master/cypress/fixtures/export-issues.xml](https://github.com/pkp/ojs/blob/master/cypress/fixtures/export-issues.xml)
-* Sample XML file for issue metadata: [https://github.com/pkp/ojs/blob/master/plugins/importexport/native/tests/functional/testissue.xml](https://github.com/pkp/ojs/blob/master/plugins/importexport/native/tests/functional/testissue.xml)
-* XML schema for use across PKP software applications: [https://github.com/pkp/pkp-lib/blob/master/plugins/importexport/native/pkp-native.xsd](https://github.com/pkp/pkp-lib/blob/master/plugins/importexport/native/pkp-native.xsd)
-* XML schema for use in OJS: [https://github.com/pkp/ojs/blob/master/plugins/importexport/native/native.xsd](https://github.com/pkp/ojs/blob/master/plugins/importexport/native/native.xsd)
+* Sample XML file for article metadata: [https://github.com/pkp/ojs/blob/main/cypress/fixtures/export-issues.xml](https://github.com/pkp/ojs/blob/main/cypress/fixtures/export-issues.xml)
+* Sample XML file for issue metadata: [https://github.com/pkp/ojs/blob/main/plugins/importexport/native/tests/functional/testissue.xml](https://github.com/pkp/ojs/blob/main/plugins/importexport/native/tests/functional/testissue.xml)
+* XML schema for use across PKP software applications: [https://github.com/pkp/pkp-lib/blob/main/plugins/importexport/native/pkp-native.xsd](https://github.com/pkp/pkp-lib/blob/main/plugins/importexport/native/pkp-native.xsd)
+* XML schema for use in OJS: [https://github.com/pkp/ojs/blob/main/plugins/importexport/native/native.xsd](https://github.com/pkp/ojs/blob/main/plugins/importexport/native/native.xsd)
 
 \* Please note that the XML format used by the Native XML Plugin for OJS 3 is different from the XML format for the Articles and Issues XML Plugin used in OJS 2.  If you export data from OJS 2 and want to import it into OJS 3, you will have to edit the XML file first. Also note that the schema is revised periodically; if exporting from one version of OJS and importing into a different version, you may need to adjust the XML slightly to account for these changes.
 
@@ -95,7 +95,7 @@ To use this plugin you will need the following:
 * A basic understanding of XML
 * To be enrolled as a Journal Manager in the OJS journal
 
-If you are importing users into OJS, first create the XML import file.  Here is a sample XML import file: [https://github.com/pkp/ojs/blob/master/plugins/importexport/users/sample.xml](https://github.com/pkp/ojs/blob/master/plugins/importexport/users/sample.xml)
+If you are importing users into OJS, first create the XML import file.  Here is a sample XML import file: [https://github.com/pkp/ojs/blob/main/plugins/importexport/users/sample.xml](https://github.com/pkp/ojs/blob/main/plugins/importexport/users/sample.xml)
 
 \* Please note that the XML format used by the Users XML Plugin in OJS 3 is different from the XML format used by the Plugin in OJS 2.  If you export data from OJS 2 and want to import it into OJS 3, you will have to edit the XML file first.
 
@@ -148,11 +148,11 @@ OJS has plugins that allow you to export article metadata to external sites and 
 
 ### PubMed XML Export Plugin
 
-The PubMed XML Export Plugin allows you to export article metadata as an XML file in NLM PubMed/MEDLINE format. For more information about the Plugin, see its README file: [https://github.com/pkp/ojs/tree/master/plugins/importexport/pubmed](https://github.com/pkp/ojs/tree/master/plugins/importexport/pubmed)
+The PubMed XML Export Plugin allows you to export article metadata as an XML file in NLM PubMed/MEDLINE format. For more information about the Plugin, see its README file: [https://github.com/pkp/ojs/tree/main/plugins/importexport/pubmed](https://github.com/pkp/ojs/tree/main/plugins/importexport/pubmed)
 
 ### DataCite Export/Registration Plugin
 
-The DataCite Export/Registration Plugin allows you to export issue, article, galley, and supplementary file metadata in DataCite format and register DOIs with DataCite. For more information about the Plugin, see its README file: [https://github.com/pkp/ojs/blob/master/plugins/importexport/datacite/README](https://github.com/pkp/ojs/blob/master/plugins/importexport/datacite/README)
+The DataCite Export/Registration Plugin allows you to export issue, article, galley, and supplementary file metadata in DataCite format and register DOIs with DataCite. For more information about the Plugin, see its README file: [https://github.com/pkp/ojs/blob/main/plugins/importexport/datacite/README](https://github.com/pkp/ojs/blob/main/plugins/importexport/datacite/README)
 
 ### DOAJ Export Plugin
 
@@ -182,7 +182,7 @@ The Crossref XML Export Plugin allows you to automatically and manually export a
 
 ### mEDRA Export/Registration Plugin
 
-The mEDRA Export/Registration Plugin allows you to export issue, article, and galley metadata in Onix for DOI \(O4DOI\) format and register DOIs with the mEDRA registration agency.  For information about how to use the plugin, see its README file: [https://github.com/pkp/ojs/blob/master/plugins/importexport/medra/README](https://github.com/pkp/ojs/blob/master/plugins/importexport/medra/README)
+The mEDRA Export/Registration Plugin allows you to export issue, article, and galley metadata in Onix for DOI \(O4DOI\) format and register DOIs with the mEDRA registration agency. For information about how to use the plugin, see its README file: [https://github.com/pkp/medra/blob/main/README](https://github.com/pkp/medra/blob/main/README)
 
 ## Use import/export plugins from the command line
 

--- a/admin-guide/en/email.md
+++ b/admin-guide/en/email.md
@@ -2,7 +2,7 @@
 
 This chapter explains how emails are sent in OJS, OMP, and OCS; the configuration options that are available; and how to troubleshoot email issues.
 
-Mail in PKP software applications uses [the PHPMailer library](https://github.com/PHPMailer/PHPMailer). You can find out more about PHPMailer on [their wiki](https://github.com/PHPMailer/PHPMailer/wiki). Other code related to mail can be found in [the pkp-lib mail class](https://github.com/pkp/pkp-lib/tree/master/classes/mail).
+Mail in PKP software applications uses [the PHPMailer library](https://github.com/PHPMailer/PHPMailer). You can find out more about PHPMailer on [their wiki](https://github.com/PHPMailer/PHPMailer/wiki). Other code related to mail can be found in [the pkp-lib mail class](https://github.com/pkp/pkp-lib/tree/main/classes/mail).
 
 Records of emails that are sent are stored in the `email_log` table of the database.
 

--- a/admin-guide/en/troubleshooting.md
+++ b/admin-guide/en/troubleshooting.md
@@ -277,7 +277,7 @@ If you are running PHP 5.3+ \(which you should be doing\), you will need to run 
 
 If you are running PHP 7+, you will need to run OJS 3.0+.
 
-OJS and OMP 3.1.2+ **requires** PHP 7.1 or above. Refer to [docs/README](https://github.com/pkp/ojs/tree/master/docs) for your OJS/OMP version for more information about PHP system requirements.
+OJS and OMP 3.1.2+ **requires** PHP 7.1 or above. Refer to [docs/README](https://github.com/pkp/ojs/tree/main/docs) for your OJS/OMP version for more information about PHP system requirements.
 
 **NOTE**: If you are running OJS or OMP 3.x on a PHP7+ LAMP stack, please remember to update your MySQL driver parameter\(Database section\) on `config.inc.php` file, i.e.:
 

--- a/admin-guide/fr/data-import-and-export.md
+++ b/admin-guide/fr/data-import-and-export.md
@@ -34,10 +34,10 @@ Pour utiliser ce plugiciel, vous aurez besoin de:
 
 Si vous importez des données, créez premièrement le fichier d'importation XML. Voici des liens vers des exemples de fichiers d'importation XML et de schémas XML:
 
-- Exemple de fichier XML pour les métadonnées d'article: [https://github.com/pkp/ojs/blob/master/plugins/importexport/native/sample.xml](https://github.com/pkp/ojs/blob/master/plugins/importexport/native/sample.xml)
-- Exemple de fichier XML pour les métadonnées de publication: [https://github.com/pkp/ojs/blob/master/plugins/importexport/native/tests/functional/testissue.xml](https://github.com/pkp/ojs/blob/master/plugins/importexport/native/tests/functional/testissue.xml)
-- Schéma XML à utiliser dans les applications logicielles PKP: [https://github.com/pkp/pkp-lib/blob/master/plugins/importexport/native/pkp-native.xsd](https://github.com/pkp/pkp-lib/blob/master/plugins/importexport/native/pkp-native.xsd)
-- Schéma XML à utiliser dans OJS: [https://github.com/pkp/ojs/blob/master/plugins/importexport/native/native.xsd](https://github.com/pkp/ojs/blob/master/plugins/importexport/native/native.xsd)
+- Exemple de fichier XML pour les métadonnées d'article: [https://github.com/pkp/ojs/blob/main/plugins/importexport/native/sample.xml](https://github.com/pkp/ojs/blob/main/plugins/importexport/native/sample.xml)
+- Exemple de fichier XML pour les métadonnées de publication: [https://github.com/pkp/ojs/blob/main/plugins/importexport/native/tests/functional/testissue.xml](https://github.com/pkp/ojs/blob/main/plugins/importexport/native/tests/functional/testissue.xml)
+- Schéma XML à utiliser dans les applications logicielles PKP: [https://github.com/pkp/pkp-lib/blob/main/plugins/importexport/native/pkp-native.xsd](https://github.com/pkp/pkp-lib/blob/main/plugins/importexport/native/pkp-native.xsd)
+- Schéma XML à utiliser dans OJS: [https://github.com/pkp/ojs/blob/main/plugins/importexport/native/native.xsd](https://github.com/pkp/ojs/blob/main/plugins/importexport/native/native.xsd)
 
 * Veuillez noter que le format XML utilisé par le plugiciel Native XML pour OJS 3 est différent du format XML pour le plugiciel XML Articles and Issues utilisé dans OJS 2. Si vous exportez des données depuis OJS 2 et que vous voulez les importer dans OJS 3, vous devrez premièrement modifier le fichier XML. Notez également que le schéma est révisé périodiquement; si vous exportez à partir d'une version d'OJS et que vous importez dans une autre version, vous devrez peut-être ajuster légèrement le XML pour tenir compte de ces changements.
 
@@ -93,7 +93,7 @@ Pour utiliser ce plugiciel, vous aurez besoin des éléments suivants:
 - Une compréhension de base de XML
 - Être inscrit en tant que Directeur/trice de la revue dans la revue OJS
 
-Si vous importez des utilisateurs dans OJS, créez premièrement le fichier d'importation XML. Voici un exemple de fichier d'importation XML: [https://github.com/pkp/ojs/blob/master/plugins/importexport/users/sample.xml](https://github.com/pkp/ojs/blob/master/plugins/importexport/users/sample.xml)
+Si vous importez des utilisateurs dans OJS, créez premièrement le fichier d'importation XML. Voici un exemple de fichier d'importation XML: [https://github.com/pkp/ojs/blob/main/plugins/importexport/users/sample.xml](https://github.com/pkp/ojs/blob/main/plugins/importexport/users/sample.xml)
 
 * Veuillez noter que le format XML utilisé par le plugiciel XML Users dans OJS 3 est différent du format XML utilisé par le plugiciel dans OJS 2. Si vous exportez des données depuis OJS 2 et que vous souhaitez les importer dans OJS 3, vous devrez d'abord modifier le fichier XML.
 
@@ -135,11 +135,11 @@ OJS a des plugiciels qui vous permettent d'exporter des métadonnées d'article 
 
 ### Plugiciel PubMed XML Export
 
-Le plugiciel PubMed XML Export vous permet d'exporter les métadonnées d'article sous forme de fichier XML au format NLM PubMed/MEDLINE. Pour plus d'informations sur le plugiciel, consultez son fichier README: [https://github.com/pkp/ojs/tree/master/plugins/importexport/pubmed](https://github.com/pkp/ojs/tree/master/plugins/importexport/pubmed)
+Le plugiciel PubMed XML Export vous permet d'exporter les métadonnées d'article sous forme de fichier XML au format NLM PubMed/MEDLINE. Pour plus d'informations sur le plugiciel, consultez son fichier README: [https://github.com/pkp/ojs/tree/main/plugins/importexport/pubmed](https://github.com/pkp/ojs/tree/main/plugins/importexport/pubmed)
 
 ### Plugiciel DataCite Export/Registration
 
-Le plugiciel DataCite Export/Registration vous permet d'exporter des métadonnées de publication, d'article, et de fichiers supplémentaires au format DataCite et d'enregistrer les DOI avec DataCite. Pour plus d'informations sur le plugiciel, consultez son fichier README: [https://github.com/pkp/ojs/blob/master/plugins/importexport/datacite/README](https://github.com/pkp/ojs/blob/master/plugins/importexport/datacite/README)
+Le plugiciel DataCite Export/Registration vous permet d'exporter des métadonnées de publication, d'article, et de fichiers supplémentaires au format DataCite et d'enregistrer les DOI avec DataCite. Pour plus d'informations sur le plugiciel, consultez son fichier README: [https://github.com/pkp/ojs/blob/main/plugins/importexport/datacite/README](https://github.com/pkp/ojs/blob/main/plugins/importexport/datacite/README)
 
 ### Plugiciel DOAJ Export
 
@@ -169,7 +169,7 @@ Le plugiciel Crossref XML Export vous permet d'exporter les métadonnées d'arti
 
 ### Plugiciel mEDRA Export/Registration
 
-Le plugiciel mEDRA Export/Registration vous permet d'exporter des métadonnées de publications, d'articles et de fichiers au format Onix for DOI (O4DOI) et d'enregistrer les DOI avec l'agence d'enregistrement mEDRA. Pour plus d'informations sur l'utilisation du plugiciel, consultez son fichier README: [https://github.com/pkp/ojs/blob/master/plugins/importexport/medra/README](https://github.com/pkp/ojs/blob/master/plugins/importexport/medra/README)
+Le plugiciel mEDRA Export/Registration vous permet d'exporter des métadonnées de publications, d'articles et de fichiers au format Onix for DOI (O4DOI) et d'enregistrer les DOI avec l'agence d'enregistrement mEDRA. Pour plus d'informations sur l'utilisation du plugiciel, consultez son fichier README: [https://github.com/pkp/medra/blob/main/README](https://github.com/pkp/medra/blob/main/README)
 
 ## Utiliser les plugiciels d'import/export depuis la ligne de commande
 

--- a/admin-guide/fr/email.md
+++ b/admin-guide/fr/email.md
@@ -2,7 +2,7 @@
 
 Ce chapitre explique comment les emails sont envoyés dans OJS, OMP et OCS; les options de configuration disponibles; et comment résoudre les problèmes de messagerie.
 
-Le courrier dans les applications logicielles PKP utilise [la bibliothèque PHPMailer](https://github.com/PHPMailer/PHPMailer) . Vous pouvez en savoir plus à propos de PHPMailer sur [leur wiki](https://github.com/PHPMailer/PHPMailer/wiki). D'autres codes liés au courrier peuvent être trouvés dans [la classe mail pkp-lib](https://github.com/pkp/pkp-lib/tree/master/classes/mail) .
+Le courrier dans les applications logicielles PKP utilise [la bibliothèque PHPMailer](https://github.com/PHPMailer/PHPMailer) . Vous pouvez en savoir plus à propos de PHPMailer sur [leur wiki](https://github.com/PHPMailer/PHPMailer/wiki). D'autres codes liés au courrier peuvent être trouvés dans [la classe mail pkp-lib](https://github.com/pkp/pkp-lib/tree/main/classes/mail) .
 
 Les enregistrements des emails envoyés sont stockés dans la table `email_log` de la base de données.
 

--- a/admin-guide/fr/troubleshooting.md
+++ b/admin-guide/fr/troubleshooting.md
@@ -278,7 +278,7 @@ Si vous utilisez PHP 5.3+ (ce que vous devriez faire), vous devrez exécuter OJS
 
 Si vous utilisez PHP 7+, vous devrez exécuter OJS 3.0+.
 
-OJS et OMP 3.1.2+ **nécessitent** PHP 7.1 ou supérieur. Faire référence à [docs/README](https://github.com/pkp/ojs/tree/master/docs) pour votre version OJS/OMP pour plus d'informations sur les exigences du système PHP.
+OJS et OMP 3.1.2+ **nécessitent** PHP 7.1 ou supérieur. Faire référence à [docs/README](https://github.com/pkp/ojs/tree/main/docs) pour votre version OJS/OMP pour plus d'informations sur les exigences du système PHP.
 
 **REMARQUE** : Si vous exécutez OJS ou OMP 3.x sur un stack PHP7 + LAMP, n'oubliez pas de mettre à jour le paramètre de votre driver MySQL (section Base de Données) sur le fichier `config.inc.php` , c'est-à-dire:
 

--- a/contributing/en/create-and-edit.md
+++ b/contributing/en/create-and-edit.md
@@ -210,7 +210,7 @@ This page is where you would enter a more detailed description of what you chang
 
 In this final page, you also have the option to create your pull request or create a draft pull request. A pull request indicates that you have completed your changes and lets the PKP team members know to review your changes. Meanwhile, a draft pull request allows you to continue to make changes.
 
-*If you are a member of the PKP team, you’ll see the ability to commit directly to the master branch*. It’s important to note that these changes are immediate, but they are also unreviewed. Please do not commit directly to master. We recommend that you always commit code via pull request.
+*If you are a member of the PKP team, you’ll see the ability to commit directly to the main branch*. It’s important to note that these changes are immediate, but they are also unreviewed. Please do not commit directly to main. We recommend that you always commit code via pull request.
 
 ## Save and Continue Edits to Branch
 

--- a/contributing/en/gettingstarted.md
+++ b/contributing/en/gettingstarted.md
@@ -34,7 +34,7 @@ The README.md file should include a brief introduction regarding the document, a
 
 ## Branches and Pull Requests
 
-A branch is a version of the repository that contains the changes you’ve proposed, uniquely. Since it is not part of “master”, it won’t have an impact on the way the site is built in real-time.
+A branch is a version of the repository that contains the changes you’ve proposed, uniquely. Since it is not part of "main", it won’t have an impact on the way the site is built in real-time.
 
 As most users will not have direct access to make changes to the PKP repository, they will need to create a branch to make changes. If you do not have full permission you will come across the message box below.
 

--- a/contributing/en/style-and-format.md
+++ b/contributing/en/style-and-format.md
@@ -30,7 +30,7 @@ When using pronouns to refer to a generic user, use gender-neutral pronouns such
 
 ## Attribution
 
-Contributors to a document, including authors and translators, can be noted in the Index.md file for a document. See [this example](https://raw.githubusercontent.com/pkp/pkp-docs/master/learning-ojs/index.md) for how contributor credits should be formatted.
+Contributors to a document, including authors and translators, can be noted in the Index.md file for a document. See [this example](https://raw.githubusercontent.com/pkp/pkp-docs/main/learning-ojs/index.md) for how contributor credits should be formatted.
 
 If documentation they contributed changes substantially over time, their names may be removed.
 

--- a/designing-your-journal/en/branding.md
+++ b/designing-your-journal/en/branding.md
@@ -217,9 +217,9 @@ The recommended image dimensions will vary depending on the base theme you have 
 
 For the Health Sciences and Classic themes, detailed information about images and dimensions can be found in their README files:
 
-* Health Sciences: [https://github.com/pkp/healthSciences/blob/master/README.md](https://github.com/pkp/healthSciences/blob/master/README.md)
-* Classic: [https://github.com/pkp/classic/blob/master/README.md](https://github.com/pkp/classic/blob/master/README.md)
-* Bootstrap: [https://github.com/NateWr/bootstrap3/blob/master/README.md](https://github.com/pkp/classic/blob/master/README.md)
+* Health Sciences: [https://github.com/pkp/healthSciences/blob/main/README.md](https://github.com/pkp/healthSciences/blob/main/README.md)
+* Classic: [https://github.com/pkp/classic/blob/main/README.md](https://github.com/pkp/classic/blob/main/README.md)
+* Bootstrap: [https://github.com/NateWr/bootstrap3/blob/master/README.md](https://github.com/NateWr/bootstrap3/blob/master/README.md)
 
 Other themes do not have image information in their README files. See [the Themes chapter of the Theming Guide](/pkp-theming-guide/en/themes) for further information on these themes.
 

--- a/dev/api/index.md
+++ b/dev/api/index.md
@@ -172,7 +172,7 @@ A few of the REST API endpoints are for internal use only and may be changed wit
 
 ## Updating the API documentation
 
-Developers should update the API documentation whenever their code modifies a request or response. The API endpoints and query parameters are defined in an [OpenAPI v3 specification](https://github.com/pkp/ojs/blob/master/docs/dev/swagger-source.json)
+Developers should update the API documentation whenever their code modifies a request or response. The API endpoints and query parameters are defined in an [OpenAPI v3 specification](https://github.com/pkp/ojs/blob/main/docs/dev/swagger-source.json)
 
 
 Several `definitions` are left undefined in the specification file.

--- a/dev/documentation/en/getting-started.md
+++ b/dev/documentation/en/getting-started.md
@@ -102,20 +102,20 @@ Run the following commands whenever you want to pull the latest changes to your 
 
 ```
 # Update the app
-git checkout master
-git pull upstream master
+git checkout main
+git pull upstream main
 git push
 
 # Update the pkp-lib submodule
 cd lib/pkp
-git checkout master
-git pull upstream master
+git checkout main
+git pull upstream main
 git push
 
 # Update the ui-library submodule
 cd ../ui-library
-git checkout master
-git pull upstream master
+git checkout main
+git pull upstream main
 git push
 
 cd ../..

--- a/dev/plugin-guide/en/release.md
+++ b/dev/plugin-guide/en/release.md
@@ -16,7 +16,7 @@ Each release of your plugin must be made available for download publicly. We pre
 
 The plugin must be made available under a GPL-compatible license so that our community can retain ownership over their publishing software. This licensing must be explicit in the code, usually by including a `LICENSE` file in the root directory of the plugin.
 
-See an [example](https://github.com/pkp/pluginTemplate/blob/master/LICENSE) of a license file.
+See an [example](https://github.com/pkp/pluginTemplate/blob/main/LICENSE) of a license file.
 
 ## Write Tests for Your plugin
 

--- a/dev/release-notebooks/en/3.2-release-notebook.md
+++ b/dev/release-notebooks/en/3.2-release-notebook.md
@@ -92,7 +92,7 @@ Once a `Submission` has been published, it will remain `STATUS_PUBLISHED` as lon
 
 ## Integration testing migrated to Cypress
 
-We now use [Cypress](https://www.cypress.io/) for our integration testing. This applies to the full suite of tests for [OJS](https://github.com/pkp/ojs/tree/master/cypress) and [OMP](https://github.com/pkp/omp/tree/master/cypress) as well as plugin integration tests (see [Static Pages](https://github.com/pkp/staticPages/tree/master/cypress/)).
+We now use [Cypress](https://www.cypress.io/) for our integration testing. This applies to the full suite of tests for [OJS](https://github.com/pkp/ojs/tree/main/cypress) and [OMP](https://github.com/pkp/omp/tree/main/cypress) as well as plugin integration tests (see [Static Pages](https://github.com/pkp/staticPages/tree/main/cypress/)).
 
 Learn more in our documentation on [testing](/dev/testing/en).
 

--- a/dev/release-notebooks/en/3.3-release-notebook.md
+++ b/dev/release-notebooks/en/3.3-release-notebook.md
@@ -154,7 +154,7 @@ $response = $client->request('GET', 'http://some-url-here');
 $body = $response->getBody();
 ```
 
-View the new [proxy config](https://github.com/pkp/ojs/blob/master/config.TEMPLATE.inc.php) and a [commit](https://github.com/pkp/ojs/commit/7f93397d82b95922443ce6ddb4e4fe968f1b3a32) with several code migrations from cURL to Guzzle.
+View the new [proxy config](https://github.com/pkp/ojs/blob/main/config.TEMPLATE.inc.php) and a [commit](https://github.com/pkp/ojs/commit/7f93397d82b95922443ce6ddb4e4fe968f1b3a32) with several code migrations from cURL to Guzzle.
 
 ## Review types
 

--- a/pkp-theming-guide/en/theme-api.md
+++ b/pkp-theming-guide/en/theme-api.md
@@ -1,6 +1,6 @@
 # Theme API Documentation
 
-Every theme extends the core [`ThemePlugin`](https://github.com/pkp/pkp-lib/blob/master/classes/plugins/ThemePlugin.inc.php) class. This class has a number of methods that will help you load scripts and styles, modify parent stylesheets and more.
+Every theme extends the core [`ThemePlugin`](https://github.com/pkp/pkp-lib/blob/main/classes/plugins/ThemePlugin.inc.php) class. This class has a number of methods that will help you load scripts and styles, modify parent stylesheets and more.
 
 This section contains technical documentation of this PHP class. If you're not familiar with the theme class, and how it relates to styles, scripts and templates, you should [begin here](what-is-a-theme.md).
 

--- a/pkp-theming-guide/en/theme-classic.md
+++ b/pkp-theming-guide/en/theme-classic.md
@@ -6,4 +6,4 @@ The Classic Theme should bring to mind classics and scholarship. It uses a serif
 
 Classic features a block-based layout for an issue’s table of contents, which makes great use of larger screens. But it also collapses into a clean, accessible view for smaller screens. The theme comes with an arresting yellow as the default primary colour to bring energy to a traditional style, but you can choose whatever color fits your brand. 
 
-Installation and configuration instructions are available in the theme plugin's [style guide](https://github.com/pkp/classic/blob/master/README.md).
+Installation and configuration instructions are available in the theme plugin's [style guide](https://github.com/pkp/classic/blob/main/README.md).

--- a/pkp-theming-guide/en/theme-default.md
+++ b/pkp-theming-guide/en/theme-default.md
@@ -10,4 +10,4 @@ The Default Theme has deliberately chosen a simple, no-fuss layout with a neutra
 
 As of OJS/OMP/OPS 3.3, the Default Theme has been externally audited for accessibility and adheres to best practices like colour contrast, keyboard navigation, and form/link focus. Note that changes made to the theme may impact accessibility.
 
-The simple structure of the Default Theme makes it easier to extend with [Child Themes](child-themes.md). A large set of [LESS variables](https://github.com/pkp/ojs/blob/master/plugins/themes/default/styles/variables.less) can be adjusted to override font sizes, colors, borders, responsive breakpoints and more.
+The simple structure of the Default Theme makes it easier to extend with [Child Themes](child-themes.md). A large set of [LESS variables](https://github.com/pkp/ojs/blob/main/plugins/themes/default/styles/variables.less) can be adjusted to override font sizes, colors, borders, responsive breakpoints and more.

--- a/pkp-theming-guide/en/theme-healthsciences.md
+++ b/pkp-theming-guide/en/theme-healthsciences.md
@@ -1,7 +1,7 @@
 # Health Sciences Theme
 
-The Health Sciences Theme is an official theme for OJS 3.1.1+ designed for health science journals or any journal that wants a clean, modern appearance. Using the contemporary and humanist typeface, Fira Sans, this theme was designed with cleanliness, simplicity and accessibility in mind. 
+The Health Sciences Theme is an official theme for OJS 3.1.1+ designed for health science journals or any journal that wants a clean, modern appearance. Using the contemporary and humanist typeface, Fira Sans, this theme was designed with cleanliness, simplicity and accessibility in mind.
 
 [This OJS site](https://demo.publicknowledgeproject.org/ojs3/demo/index.php/health-sciences) demonstrates the Health Sciences theme.
 
-Installation and configuration instructions are available in the theme's [style guide](https://github.com/pkp/healthSciences/blob/master/README.md).
+Installation and configuration instructions are available in the theme's [style guide](https://github.com/pkp/healthSciences/blob/main/README.md).

--- a/pkp-theming-guide/en/theme-immersion.md
+++ b/pkp-theming-guide/en/theme-immersion.md
@@ -6,4 +6,4 @@ Immersion emphasizes the reading experience and offers bold design options such 
 
 This theme allows you to display a full-width image in the header. When used appropriately, the image and color options can provide a striking aesthetic that will stand out from other journals. This effect may work best for arts and culture journals which want to present a more ambitious visual profile.
 
-Installation and configuration instructions are available in the theme's [style guide](https://github.com/pkp/immersion/blob/master/README.md).
+Installation and configuration instructions are available in the theme's [style guide](https://github.com/pkp/immersion/blob/main/README.md).

--- a/pkp-theming-guide/en/theme-manuscript.md
+++ b/pkp-theming-guide/en/theme-manuscript.md
@@ -7,4 +7,3 @@ Manuscript is a clean, simple theme with a boxed layout that mimics a paper docu
 The theme really shines when you configure your journal without a sidebar, benefiting from generous spacing that brings focus to the main content. But it looks great regardless of whether or not you use the sidebar. Just like the default theme, you can tailor the colours to match your journal’s branding.
 
 Installation and configuration instructions are available in the theme's [style guide](https://github.com/NateWr/defaultManuscript/blob/master/readme.md).
-

--- a/pkp-theming-guide/pt-br/theme-api.md
+++ b/pkp-theming-guide/pt-br/theme-api.md
@@ -1,6 +1,6 @@
 # Documentação da API de Tema
 
-Todo tema estende a classe principal do [`ThemePlugin`](https://github.com/pkp/pkp-lib/blob/master/classes/plugins/ThemePlugin.inc.php). Esta classe tem um número de métodos que auxiliam no carregamento de _scripts_ e estilos, além de modificar as folhas de estilo Pai entre outras coisas.
+Todo tema estende a classe principal do [`ThemePlugin`](https://github.com/pkp/pkp-lib/blob/main/classes/plugins/ThemePlugin.inc.php). Esta classe tem um número de métodos que auxiliam no carregamento de _scripts_ e estilos, além de modificar as folhas de estilo Pai entre outras coisas.
 
 Esta seção abrange a documentação técnica desta classe PHP. Caso você não esteja familiarizado com classe de tema e como isto se relaciona com estilos, _scripts_ e _templates_ então [comece por aqui](what-is-a-theme.md).
 

--- a/pkp-theming-guide/pt-br/theme-default.md
+++ b/pkp-theming-guide/pt-br/theme-default.md
@@ -6,4 +6,4 @@ A tipografia padrão utiliza a fonte da família [Noto](https://www.google.com/g
 
 O Tema Padrão deliberadamente escolheu um layout simples, sem conflitos  e com uma paleta de cores neutra. Isso torna mais fácil para que a sua marca  se destaque com apenas algumas mudanças simples de cor e tipografia em uso.
 
-A estrutura simples do Tema Padrão facilita estender as funcionalidades utilizando [Temas Filhos](child-themes.md). Um grande conjunto de [variáveis LESS](https://github.com/pkp/ojs/blob/master/plugins/themes/default/styles/variables.less) pode ser ajustado para sobrepor definições de tamanhos, cores, bordas, pontos de interrupção responsivos entre outras coisas.
+A estrutura simples do Tema Padrão facilita estender as funcionalidades utilizando [Temas Filhos](child-themes.md). Um grande conjunto de [variáveis LESS](https://github.com/pkp/ojs/blob/main/plugins/themes/default/styles/variables.less) pode ser ajustado para sobrepor definições de tamanhos, cores, bordas, pontos de interrupção responsivos entre outras coisas.

--- a/translating-guide/en/translate-software.md
+++ b/translating-guide/en/translate-software.md
@@ -6,7 +6,7 @@ version: 3.2
 
 Starting with OJS/OMP 3.2, we are using the web-based translation tool [Weblate](https://weblate.org) to manage translations of OJS and OMP.
 
-This means we have moved away from using XML files, and are instead using ["monolingual"](https://docs.weblate.org/en/latest/formats.html) PO files. These two file formats look a little different but support the same information. For example, here is an [XML file](https://github.com/pkp/pkp-lib/blob/stable-3_1_2/locale/en_US/common.xml) and a [PO file](https://github.com/pkp/pkp-lib/blob/master/locale/en_US/common.po).
+This means we have moved away from using XML files, and are instead using ["monolingual"](https://docs.weblate.org/en/latest/formats.html) PO files. These two file formats look a little different but support the same information. For example, here is an [XML file](https://github.com/pkp/pkp-lib/blob/stable-3_1_2/locale/en_US/common.xml) and a [PO file](https://github.com/pkp/pkp-lib/blob/main/locale/en_US/common.po).
 
 PO files are used by many thousands of software projects worldwide to manage translations. There are good-quality third-party tools for working with these. We have chosen Weblate, which supports web-based translation. This will replace our [Translator plugin](https://github.com/pkp/translator/).
 

--- a/upgrading-ojs-2-to-3/en/resources.md
+++ b/upgrading-ojs-2-to-3/en/resources.md
@@ -5,7 +5,7 @@
 -   [Learning OJS 3.1: A Visual Guide to Open Journal Systems](https://docs.pkp.sfu.ca/learning-ojs/) offers user guides, developer information, and publishing tips for OJS 3.
 -   [OJS 3 Demo](https://pkp.sfu.ca/ojs/ojs_demo/): Explore how OJS 3 works by trying out the demo and test drive sites hosted by PKP.
 -   [PKP School](https://pkpschool.sfu.ca/) offers free video courses to assist users with various aspects of OJS 3, in both English and Spanish. You will need to create a free account and log in to the site in order to participate. The videos are also available at [PKP’s YouTube channel](https://www.youtube.com/user/PublicKnowledgeProj).
--   [OJS 3.1.2 Release Notes](https://github.com/pkp/ojs/blob/master/docs/release-notes/README-3.1.2) lists new features.
+-   [OJS Release Notes](https://github.com/pkp/ojs/blob/main/docs/release-notes) lists new features.
 -   [PKP Docs What’s New in OJS 3](https://docs.pkp.sfu.ca/learning-ojs/en/introduction#whats-new-in-ojs-3) outlines interface changes for readers & editors.
 -   [Major New Features in Upcoming OJS 3](https://pkp.sfu.ca/2016/08/05/major-new-features-in-upcoming-ojs-3/) is a pre-release blog post from 2016.
 

--- a/upgrading-ojs-2-to-3/es/resources.md
+++ b/upgrading-ojs-2-to-3/es/resources.md
@@ -5,7 +5,7 @@
 - [Aprender OJS 3.1: una guía visual de Open Journal Systems](https://docs.pkp.sfu.ca/learning-ojs/) ofrece guías de usuario/a, información para desarrolladores/as y consejos de publicación para OJS 3.
 - [Demo de OJS 3](https://pkp.sfu.ca/ojs/ojs_demo/): explore cómo funciona OJS 3 probando los sitios de demostración y testeo alojados por PKP.
 - [PKP School](https://pkpschool.sfu.ca/) ofrece cursos en vídeo gratuitos para ayudar a los usuarios/as con diversos aspectos de OJS 3, tanto en inglés como en español. Deberá crear una cuenta gratuita e iniciar sesión en el sitio para poder participar. Los vídeos también están disponibles en el [canal de YouTube de PKP](https://www.youtube.com/user/PublicKnowledgeProj).
-- En las [notas de lanzamiento de OJS 3.1.2](https://github.com/pkp/ojs/blob/master/docs/release-notes/README-3.1.2) se enumeran nuevas características.
+- En las [notas de lanzamiento de OJS 3.1.2](https://github.com/pkp/ojs/blob/main/docs/release-notes/README-3.1.2) se enumeran nuevas características.
 - En [PKP Docs novedades en OJS 3](https://docs.pkp.sfu.ca/learning-ojs/en/introduction#whats-new-in-ojs-3) se describen los cambios en la interfaz para lectores/as y editores/as.
 - [Major New Features in Upcoming OJS 3](https://pkp.sfu.ca/2016/08/05/major-new-features-in-upcoming-ojs-3/) es una publicación del blog de prelanzamiento de 2016.
 


### PR DESCRIPTION
Replaces "master" with "main" throughout the docs, as PKP's default branch name has been changed throughout. Resolves #623. 