### PR TITLE
Remove "screenshot of" or "image of" in alt-text across multiple docs

### DIFF
--- a/accessible-content/en/galleys.md
+++ b/accessible-content/en/galleys.md
@@ -47,11 +47,11 @@ The method you choose to export your Word Document to PDF will affect the preser
 
 Export your Word Document by using “Create PDF” from a file in Adobe Acrobat Pro. Open Adobe Acrobat Pro > File > Create > PDF from File > Select desired document to convert.
 
-![Screenshot of Acrobat Pro DC menu option to create PDF from file.](./assets/9_a11y-guide-create-pdf-pro1.png)
+![The Acrobat Pro DC menu option to create PDF from file.](./assets/9_a11y-guide-create-pdf-pro1.png)
 
 If you are creating a document via the Acrobat Tab in MS Office, make sure that **Enable Accessibility and Reflow with tagged Adobe PDF** is checked.
 
-![Screenshot of Acrobat PDFMaker with the checked checkbox to Enable Accessibility and Reflow with tagged Adobe PDF](./assets/10_a11y-guide-create-pdf-pro2.png)
+![The Acrobat PDFMaker with the checked checkbox to Enable Accessibility and Reflow with tagged Adobe PDF](./assets/10_a11y-guide-create-pdf-pro2.png)
 
 ##### Next Best Method (does not require Adobe Acrobat Pro)
 
@@ -61,13 +61,13 @@ On Windows:
 Select **File > Save As**. Select “PDF” from the list of drop-down files.
 Click “Options” and make sure **“Document structure tags for accessibility”** is checked, then save the file.
 
-![Screenshot of MS Word on Windows file save option with the checked checkbox Document structure tags for accessibility](./assets/11_a11y-guide-saveas-pdf1.png)
+![The MS Word on Windows file save option with the checked checkbox Document structure tags for accessibility](./assets/11_a11y-guide-saveas-pdf1.png)
 
 On Mac:
 Open the **File** application menu and select **Save As…**
 Under **File Format**, select “PDF”. Then choose the **Best for electronic distribution and accessibility** (**uses Microsoft online service**) radio button, then **Export**.
 
-![Screenshot of the MS Word on Mac file save option in PDF with the checked checkbox Best for electronic distribution and accessibility](./assets/12_a11y-guide-saveas-pdf2.png)
+![The MS Word on Mac file save option in PDF with the checked checkbox Best for electronic distribution and accessibility](./assets/12_a11y-guide-saveas-pdf2.png)
 
 **IMPORTANT**: **never “Print to PDF”** when exporting a Word Document to PDF. A screen reader user may still be able to access the text of a PDF created in this way, but heading structure, alternative text, and any other tag structure will be lost.
 

--- a/accessible-content/en/principles.md
+++ b/accessible-content/en/principles.md
@@ -122,7 +122,7 @@ Text colour against the background may appear as sufficiently distinct to a sigh
 
 You can use [WebAim’s Contrast Checker](https://webaim.org/resources/contrastchecker/), [Contrast Ratio Checker](https://contrast-ratio.com/), or the [Colour Contrast Analyser](https://developer.paciellogroup.com/resources/contrastanalyser/) to check the contrast ratio between your website’s background and text colours. Here is an example of a check done using [WebAim’s Contrast Checker](https://webaim.org/resources/contrastchecker/):
 
-![Screenshot of WebAim's Colour Contrast Checker interface.](./assets/1_a11y-guide-webaim-contrast-checker.png)
+![WebAim's Colour Contrast Checker interface.](./assets/1_a11y-guide-webaim-contrast-checker.png)
 
 *Example of WebAim's Colour Contrast Checker interface options*
 
@@ -213,7 +213,7 @@ Other editors will typically follow the same concept of heading ranking and nest
 
 The following image shows the heading options for Google Docs:
 
-![Screenshot of heading options in Google Doc.](./assets/7_a11y-guide-headings-doc.png)
+![The heading options in Google Doc.](./assets/7_a11y-guide-headings-doc.png)
 
 The heading hierarchy for documents on text editors should follow the same concept of rank level for HTML documents:
 

--- a/admin-guide/en/data-import-and-export.md
+++ b/admin-guide/en/data-import-and-export.md
@@ -64,7 +64,7 @@ Once you have the valid XML import file, you can import it:
 4. Click Import
 5. You will be notified of any errors, or if the import was successful.
 
-![Screenshot of XML file upload screen.](./assets/native-xml-plugin.png)
+![The XML file upload screen.](./assets/native-xml-plugin.png)
 
 To export article and issue metadata using the Native XML Plugin:
 
@@ -119,7 +119,7 @@ Once you have the valid XML import file, you can import it:
 4. Click Import Users
 5. You will be notified of any errors, or if the import was successful.
 
-![Screenshot of Users XML Plugin file uploader for importing users.](./assets/users-xml-plugin-import.png)
+![The Users XML Plugin file uploader for importing users.](./assets/users-xml-plugin-import.png)
 
 To export user accounts using the Users XML Plugin:
 
@@ -129,7 +129,7 @@ To export user accounts using the Users XML Plugin:
 4. Click Export Users
 5. The user accounts will be exported in XML format, and can be imported to this or another journal
 
-![Screenshot of Export Users tab under Users XML Plugin.](./assets/users-xml-plugin-export.png)
+![The Export Users tab under Users XML Plugin.](./assets/users-xml-plugin-export.png)
 
 ### Export users to CSV
 

--- a/admin-guide/en/single-signon.md
+++ b/admin-guide/en/single-signon.md
@@ -23,7 +23,7 @@ The title for your LDAP setup is arbitrary; leave it as is or choose your own ti
 
 The next set of settings configures OJS/OCS to allow communication with the LDAP server.
 
-![Screenshot of LDAP settings fields OJS.](./assets/LdapSettings.png)
+![The LDAP settings fields OJS.](./assets/LdapSettings.png)
 
 * *Server hostname*. The domain/IP address of the server that hosts the LDAP source. If OJS/OCS is running on the same server as LDAP, you can enter `localhost`.
 * *Server port*. If LDAP is running on a non-standard port, enter the number here. Leave it blank if you're not sure.

--- a/designing-your-journal/en/branding.md
+++ b/designing-your-journal/en/branding.md
@@ -155,28 +155,28 @@ The Home page image is the large feature image on the homepage on some themes, s
 * images with a larger width than height.
 
 <figure>
-    <img src="./assets/splash-image-dont.png" alt="Image where an oversized issue cover image has been set as the homepage image, taking up an excessive amount of space. The image is marked with a red X.">
+    <img src="./assets/splash-image-dont.png" alt="An oversized issue cover image which has been set as the homepage image, taking up an excessive amount of space. The image is marked with a red X.">
     <figcaption>The home page image should not be used for issue covers -- there is a space dedicated to this in an issue’s metadata. It is also much taller than it is wide: your readers will have to scroll before seeing your latest announcements or issue’s table of contents.</figcaption>
 </figure>
 
 <br/>
 
 <figure>
-    <img src="./assets/splash-image-dont-mobile.png" alt="Image showing the previous oversized image on a mobile display, marked with a red X.">
+    <img src="./assets/splash-image-dont-mobile.png" alt="The previous oversized image on a mobile display, marked with a red X.">
     <figcaption>Image sizing issues are magnified on mobile devices; the reader has to scroll even more. This may cause them to navigate away from your website before reading your journal’s content.</figcaption>
 </figure>
 
 <br/>
 
 <figure>
-    <img src="./assets/splash-image-dont-2.png" alt="Image of a properly sized homepage image, marked with a red X.">
+    <img src="./assets/splash-image-dont-2.png" alt="A properly sized homepage image, marked with a red X.">
     <figcaption>Original image dimensions are too small - less than 1000 pixels wide. Used as a cover or home page image, it stretches out and becomes blurry or pixelated.</figcaption>
 </figure>
 
 <br/>
 
 <figure>
-    <img src="./assets/splash-image-do.png"  alt="Image showing a properly sized homepage image, marked with a green check.">
+    <img src="./assets/splash-image-do.png"  alt="A properly sized homepage image, marked with a green check.">
     <figcaption>The image is much wider than it is tall, giving readers a better idea of the journal’s text content “above the fold” (before the reader has to scroll to see the rest of the page). A high-quality and larger (over 1200 pixels wide) PNG image looks more polished and translates well on most screens, from mobile devices to desktop HD monitors.</figcaption>
 </figure>
 
@@ -227,7 +227,7 @@ The size and manner in which images are displayed can be altered by uploading a 
 
 In OMP you can configure the size of your book cover thumbnails under Website Settings > Appearance.
 
-![Screenshot of OMP cover thumbnail dimension setting screen.](./assets/cover-thumbnails.png)
+![The OMP cover thumbnail dimension setting screen.](./assets/cover-thumbnails.png)
 
 ### Resizing images
 

--- a/designing-your-journal/en/creating-stylesheet.md
+++ b/designing-your-journal/en/creating-stylesheet.md
@@ -9,9 +9,9 @@ In OJS, the Journal Manager, Journal Editor and Production Editor can upload a c
 
 Most browsers will have several tools that can help you to inspect and test the CSS that is being used in your journal to identify the specific elements you might want to change. 
 
-For example, you can right-click on a part of a webpage (Ctrl+click on Macs), and you should see an option to “Inspect element”. In both Firefox and Chrome, this will bring up a version of “Developer tools” (named differently in each browser), which will allow you to take a closer look at the contents of a page’s HTML and CSS. 
+For example, you can right-click on a part of a webpage (Ctrl+click on Macs), and you should see an option to “Inspect element”. In both Firefox and Chrome, this will bring up a version of “Developer tools” (named differently in each browser), which will allow you to take a closer look at the contents of a page’s HTML and CSS.
 
-For example: 
+For example:
 
 ![](./assets/browser-developer-tools.png)*A screenshot of an OJS website using Firefox developer tools*
 
@@ -64,12 +64,13 @@ To learn more about the Style Editor tool, see [Firefox’s official documentati
 ### Upload your CSS file
 
 To test out your new or modified CSS before uploading it to your live journal, you can:
+
 - Upload it to your Firefox Style Editor
 - Upload it to your OJS sandbox site
 - Upload it to the PKP demo site
 
 When ready to upload your CSS, go to Settings > Website > Appearance > Journal Style Sheet and click **Upload**.
 
-![Screenshot of Journal style sheet upload button in OJS.](./assets/upload-stylesheet.png)
+![The journal style sheet upload button in OJS.](./assets/upload-stylesheet.png)
 
 When you're satisfied with the result, be sure to test your website on several devices, including laptops, tablets and phones, to ensure that you are happy with the way it looks no matter how your users access the journal's website.

--- a/dev/testing/en/continuous-integration.md
+++ b/dev/testing/en/continuous-integration.md
@@ -8,7 +8,7 @@ We use [Travis CI](https://travis-ci.com) for Continuous Integration (CI) testin
 
 CI tests are configured to run the tests against multiple PHP versions and databases. The configuration details are stored in the `.travis.yml` file in the application's root directory.
 
-![Screenshot of OJS test result in Travis.](./travis-overview.png)
+![OJS test results in Travis.](./travis-overview.png)
 
 View the tests for [OJS](https://travis-ci.com/pkp/ojs/), [OMP](https://travis-ci.com/pkp/omp/) and [OPS](https://travis-ci.com/pkp/ops/).
 
@@ -16,7 +16,7 @@ View the tests for [OJS](https://travis-ci.com/pkp/ojs/), [OMP](https://travis-c
 
 Travis will run tests against every pull request to OJS or OMP. The tests are listed in the checks at the bottom of the pull request.
 
-![Screenshot of Travis check in the pull request.](./travis-pr.png)
+![A Travis check in the pull request.](./travis-pr.png)
 
 Click the **Details** link beside the Travis tests to watch the tests as they run and see which tests have passed or failed. All tests must pass before a pull request will be merged.
 

--- a/getting-found-staying-found/en/getting-found-increasing-impact.md
+++ b/getting-found-staying-found/en/getting-found-increasing-impact.md
@@ -102,7 +102,7 @@ For example, citation count in Web of Science citation counts are limited to tho
 For the same example, Google Scholar returns a higher citation count because the index is more inclusive, and also represents non-journal citations.
 
 ![Web of Science formula](assets/chapter2/google-scholar-citation.png)
-*Screenshot of article result from Google Scholar*
+*An article result from Google Scholar*
 
 #### Article Influence score
 

--- a/journal-policies-workflows/en/copyright-licensing.md
+++ b/journal-policies-workflows/en/copyright-licensing.md
@@ -79,30 +79,29 @@ There are 3 places in OJS where you can add the above information, depending on 
 Enter this information under **Settings > Distribution > License**.
 For additional details about this section see  [Learning OJS 3: Distributions Settings - License](https://docs.pkp.sfu.ca/learning-ojs/en/settings-distribution#license).
 
-![Screenshot of OJS 3.2 Distribution Settings.](./assets/journal-policies-distribution-settings.png
-)
+![The OJS 3.2 Distribution Settings.](./assets/journal-policies-distribution-settings.png)
 
 The above information will be automatically displayed on each article page:
 
-![Screenshot of display of licensing information in OJS 3 public interface.](./assets/journal-policies-published-copyright-notice.png)
+![The display of licensing information in OJS 3 public interface.](./assets/journal-policies-published-copyright-notice.png)
 
 If your journal distributes articles under different licenses, you will be able to override the above information per article in the Permissions & Disclosure section of the Publication tab:
 
-![Screenshot of display of Permissions & Disclosure settings in OJS 3.2](./assets/journal-policies-published-copyright-notice.png)
+![The display of Permissions & Disclosure settings in OJS 3.2](./assets/journal-policies-published-copyright-notice.png)
 
 **2: Add the copyright notice for authors to accept during submission and display in Author Guidelines.**
 
 This statement can be added in **Settings > Workflow > Submission > Author Guidelines > Copyright Notice.**
 
-![Screenshot of display of Permissions & Disclosure settings in OJS 3.2](./assets/journal-policies-published-copyright-notice.png)
+![The display of Permissions & Disclosure settings in OJS 3.2](./assets/journal-policies-published-copyright-notice.png)
 
 The statement will appear publicly on the Author Guidelines page to inform potential authors of the terms they will be agreeing to:
 
-![Screenshot of Author Guidelines setting in OJS 3.2](./assets/journal-policies-copyright-notice-guidelines.png)
+![The Author Guidelines setting in OJS 3.2](./assets/journal-policies-copyright-notice-guidelines.png)
 
 A checkbox to agree to this statement will be presented to the author to accept during submission:
 
-![Screenshot of copyright statement acknowledgement in OJS 3.2](./assets/journal-policies-agree-copyright-statement.png)
+![The copyright statement acknowledgement in OJS 3.2](./assets/journal-policies-agree-copyright-statement.png)
 
 Depending on the jurisdiction, a copyright transfer may need to be formally signed whereas a license may or may not require a signature. In North America it is sufficient for the author to accept the license by agreeing to publish with the journal.
 
@@ -110,6 +109,6 @@ Depending on the jurisdiction, a copyright transfer may need to be formally sign
 
 It is important to display copyright and licensing information on the article document itself, so anyone who may read, save or share it would still know how it can be used.
 
-![Screenshot of Creative Commons License source information in PDF Galley](./assets/journal-policies-agree-copyright-statement.png)
+![The Creative Commons License source information in a PDF Galley](./assets/journal-policies-agree-copyright-statement.png)
 
 Source: McCormick, A., Adams, S. A., Dunbar, H., & Mclean-Plunkett, S. (2020). Teaching Copyright Law through Participatory Involvement in an Unconference Setting. *Journal of Copyright in Education & Librarianship*, 4(1). [https://doi.org/10.17161/jcel.v4i1.13283](https://doi.org/10.17161/jcel.v4i1.13283)

--- a/learning-ojs-2/en/viewing_and_reading_overview.md
+++ b/learning-ojs-2/en/viewing_and_reading_overview.md
@@ -6,22 +6,16 @@ The following image is a screenshot of an OJS Demonstration Journal Table of Con
 
 ![Open Journal Systems Table of Contents](images/chapter1/demo_journal.png)
 
-
 The next images show HTML and PDF versions of an article, including Reading Tools in the right column.
 <br>
 <br>
 **HTML Article View**
 
-
-
-![Open Journal Systems HTML Article View](images/chapter1/demo_html_copy.png)       
-
-
+![Open Journal Systems HTML Article View](images/chapter1/demo_html_copy.png)
 
 **PDF Article View**  
 
 ![Open Journal Systems PDF Article View](images/chapter1/demo_pdf_copy.png)  
-
 
 PDFs can also be view in a full-screen mode, for a more present, uninterrupted reading experience.
 
@@ -30,16 +24,10 @@ PDFs can also be view in a full-screen mode, for a more present, uninterrupted r
 ![Open Journal Systems PDF Full-screen](images/chapter1/demo_fullscreen.png)  
 
 Finally, it's worth noting that both HTML and PDF galleys can be read on mobile devices, without the need of any special apps (aside from a web browser, of course).  
-  
-
 
 **Open Journal Systems HTML on iPhone**
 
-
-
 ![Open Journal Systems HTML on iPhone](images/chapter1/mobile_html_sm.png)
-
-
 
 <br>
 
@@ -47,14 +35,6 @@ Finally, it's worth noting that both HTML and PDF galleys can be read on mobile 
 
 <br>
 
-
-
 ![Open Journal Systems PDF on iPhone](images/chapter1/mobile_pdf_sm.png) 
 
-
-
-
 The OJS interface can be extensively customized by uploading new stylesheets at the site, journal, and article level, and by various other journal-specific customizations. For the advanced user, the underlying template system can also be modified. As open source software, you are free to customize OJS as you wish.
-
-
-

--- a/learning-ojs/3.1/en/introduction.md
+++ b/learning-ojs/3.1/en/introduction.md
@@ -55,7 +55,7 @@ _AKA "The Dashboard"_
 
 OJS 3.x now has a separate interface once you log into the editorial system. This not only makes it easier to customize the reader interface, but also provides OJS users of different journals a consistent experience.
 
-![Screenshot of the main OJS dashboard](./assets/learning-ojs3.1-ed-dashboard.png)
+![The main OJS dashboard](./assets/learning-ojs3.1-ed-dashboard.png)
 
 The editorial interface is known as your **dashboard** and consists of the following elements:
 

--- a/learning-ojs/3.1/en/journal-setup.md
+++ b/learning-ojs/3.1/en/journal-setup.md
@@ -96,7 +96,7 @@ Hit the **Save** button to save your changes and return to the Sections page.
 
 From the sections page, select the Create Section link to open a blank window, exactly the same as the window used for editing a section described above.
 
-![Screenshot of new window for entering section information in text fields and selecting section options.](./assets/learning-ojs-3-settings-website-settings-sections-create.png)
+![A new window for entering section information in text fields and selecting section options.](./assets/learning-ojs-3-settings-website-settings-sections-create.png)
 
 Fill in the details and hit Save to record your work.
 
@@ -104,28 +104,30 @@ Fill in the details and hit Save to record your work.
 
 Each section allows to restrict submissions by checking the "Items can only be submitted by Editors and Section Editors" checkbox.
 
-![Screenshot of list of options for restricting a section. Items can be selected from list by checking the box to the left of the item.](./assets/learning-ojs3.1-jm-settings-journal-sections-restrict.png)
+![The list of options for restricting a section. Items can be selected from list by checking the box to the left of the item.](./assets/learning-ojs3.1-jm-settings-journal-sections-restrict.png)
 
 If this checkbox is checked for all sections, authors will not be able to submit to the journals. Authors who select New Submission from their dashboards will now see the message "This journal is not accepting submissions at this time."
 
-![[Screenshot example of message displayed on a journal New Submission page.](./assets/learning-ojs3.1-jm-settings-journal-not-accepting-submissions.png)
+![An example of the message displayed on a journal New Submission page.](./assets/learning-ojs3.1-jm-settings-journal-not-accepting-submissions.png)
 
 ### Order Sections
 
 When you have more than one section created, you will see an Order link. Use that to reorder how those sections display on your journal website.
 
-![Screenshot of list of available sections from top to bottom of page in OJS dashboard.](./assets/learning-ojs3.1-jm-settings-journal-sections-order.png)
+![A list of available sections from top to bottom of page in OJS dashboard.](./assets/learning-ojs3.1-jm-settings-journal-sections-order.png)
 
 Hit the **Done** button when you are finished.
 
 <hr />
 
 ## Categories
+
 In OJS 3.1.2 you can create Categories to organize your articles into thematic collections and provide another way for readers to access your content. Categories can be displayed as a browse block on your journal site and readers can select a category to view all articles in that category. You can place an article in a category by editing its metadata, which is explained in the [Production section of the Editorial Settings chapter](./editorial-workflow.md#production). This section explains how to create and edit categories.
 
 ![OJS dashboard view of Journal Settings submenu Categories with links for Order and Add a Category and editable list of current categories.](./assets/learning-ojs3.1-categories-menu.png)
 
 To create a new category:
+
 * Click Add Category
 * Enter a name for your category that will be displayed to readers
 * Enter a path for the category’s URL on your site
@@ -134,14 +136,16 @@ To create a new category:
 * Optionally add an image which will appear at the top of the category’s page
 * Click Save
 
-![Screenshot of new window for entering category information in text fields and selecting category options.](./assets/learning-ojs3.1-create-category.png)
+![A new window for entering category information in text fields and selecting category options.](./assets/learning-ojs3.1-create-category.png)
 
 To edit a category:
+
 * Click the name of the category you want to edit
 * Make the changes
 * Click OK
 
 To remove a category:
+
 * Click the blue arrow next to the category you want to remove
 * Click the Remove button that appears below
 * Confirm that you want to remove the category

--- a/learning-ojs/3.1/en/reviewing.md
+++ b/learning-ojs/3.1/en/reviewing.md
@@ -6,13 +6,13 @@ version: 3.1
 
 As a reviewer, you will learn of the review request via email or by checking your dashboard:
 
-![Screenshot of assigned submissions queue in reviewer dashboard](./assets/learning-ojs-3-rev-dashboard.png)
+![The assigned submissions queue in reviewer dashboard](./assets/learning-ojs-3-rev-dashboard.png)
 
 From the My Assigned list, find the title and Review link. Notice the lack of any author information in this double-blind peer review process.
 
 Selecting the Review link will take you to the first review step in the submission record, which is much more limited than the editor’s view, and contains no author information.
 
-![Screenshot of a review request](./assets/learning-ojs-3-rev-step1.png)
+![A review request](./assets/learning-ojs-3-rev-step1.png)
 
 This first step consists of the following sections:
 
@@ -24,11 +24,11 @@ This first step consists of the following sections:
 
 Further down the screen, you will find additional information.
 
-![Screenshot showing more of the review request screen](./assets/learning-ojs-3-rev-step1-3.png)
+![More of the review request screen](./assets/learning-ojs-3-rev-step1-3.png)
 
 The **View All Submission Details** link will open a window with additional information, including all of the non-author metadata:
 
-![Screenshot of the view all submission details screen](./assets/learning-ojs-3-rev-step1-2.png)
+![The view all submission details screen](./assets/learning-ojs-3-rev-step1-2.png)
 
 Note that none of these fields are editable by the reviewer, and are only provided to help you conduct a thorough review.
 
@@ -36,15 +36,15 @@ Close this window and move further down the screen. From here you can see the Re
 
 From here, you can decline or accept the review. If you decline, you will be dropped from the process. If you accept, you will move to review step 2, where you would be able to read any reviewer guidelines provided by the journal.
 
-![Screenshot of reviewer guidelines](./assets/learning-ojs-3-rev-step2.png)
+![The reviewer guidelines](./assets/learning-ojs-3-rev-step2.png)
 
 Hit **Continue** to move to step 3. From here you can download a copy of the review files and enter your review comments. The first window is for comments to the editor and the author; the second window is just for the editor.
 
-![Screenshot of the download and review tab](./assets/learning-ojs-3-rev-step3.png)
+![The download and review tab](./assets/learning-ojs-3-rev-step3.png)
 
 Once you have read the paper and added your comments, scroll down the page to optionally upload a marked up copy of the review file \(remember to strip any personal identification from the file before uploading it\).
 
-![Screenshot of upload reviewer files and review recommendation drop down](./assets/learning-ojs-3-rev-step3-1.png)
+![The upload reviewer files and review recommendation drop down](./assets/learning-ojs-3-rev-step3-1.png)
 
 Next, you must then make your recommendation using the dropdown menu.
 
@@ -64,10 +64,10 @@ Your choices include:
 
 Finally, hit the Submit Review button to complete your task. You’ll be asked to confirm.
 
-![Screenshot of confirmation screen to submit review](./assets/learning-ojs-3-rev-step3-2.png)
+![The confirmation screen to submit review](./assets/learning-ojs-3-rev-step3-2.png)
 
 Hit OK. You will be taken to the final confirmation screen thanking you for your work.
 
-![Screenshot of review submitted completion screen](./assets/learning-ojs-3-rev-step4.png)
+![The review submitted completion screen](./assets/learning-ojs-3-rev-step4.png)
 
 That's it! The review is now complete.

--- a/learning-ojs/3.1/es/introduction.md
+++ b/learning-ojs/3.1/es/introduction.md
@@ -40,11 +40,11 @@ Por defecto, Open Journal Systems se instala con una interfaz de usuario muy sim
 
 La siguiente imagen es una captura de pantalla de un Índice de la revista de Demostración de OJS.
 
-![screenshot of an Index of the OJS Demonstration magazine](./assets/image5.png)
+![An Index of the OJS Demonstration magazine](./assets/image5.png)
 
 Puedes ver en la captura de pantalla que las funciones de usuario ahora existen en el menú de tu perfil en la parte superior derecha de la pantalla. Esto aleja el contenido de gestión en OJS 3.x de la vista general del usuario. La información de la barra lateral está claramente desglosada, así como la barra de navegación superior con menús plegables para las funciones "Acerca de". Al igual que OJS 2, cada artículo tiene un título enlazado para ver los metadatos y resúmenes de los objetos, y ahora las galerías están claramente etiquetadas debajo de los títulos con logotipos más claros.
 
-## Interfaz Editorial 
+## Interfaz Editorial
 
 _alias El Tablero_
 

--- a/learning-ojs/3.2/en/journal-setup.md
+++ b/learning-ojs/3.2/en/journal-setup.md
@@ -88,7 +88,7 @@ If you have a section that is no longer active, you can check off "Items can onl
 
 You can check off "Will not be included in the indexing of the journal" for sections that contain front matter, back matter, and anything else that might clutter the search index unnecessarily.
 
-![Screenshot of window for entering Word Count, Review Form, and Section Options.](./assets/learning-ojs-3.2-settings-section-options.png)
+![A window for entering Word Count, Review Form, and Section Options.](./assets/learning-ojs-3.2-settings-section-options.png)
 
 **Identify items published in this section as a\(n\)**: This is used by some systems. Note that it is not a required field.
 
@@ -100,7 +100,7 @@ Hit the **Save** button to save your changes and return to the Sections page.
 
 From the sections page, select the Create Section link to open a blank window, exactly the same as the window used for editing a section described above.
 
-![Screenshot of new window for entering section information in text fields and selecting section options.](./assets/learning-ojs-3.2-settings-website-settings-sections-create.png)
+![A new window for entering section information in text fields and selecting section options.](./assets/learning-ojs-3.2-settings-website-settings-sections-create.png)
 
 Fill in the details and hit Save to record your work.
 
@@ -108,17 +108,17 @@ Fill in the details and hit Save to record your work.
 
 Each section allows to restrict submissions by checking the "Items can only be submitted by Editors and Section Editors" checkbox.
 
-![Screenshot of list of options for restricting a section. Items can be selected from list by checking the box to the left of the item.](./assets/learning-ojs3.2-jm-settings-journal-sections-restrict.png)
+![A list of options for restricting a section. Items can be selected from list by checking the box to the left of the item.](./assets/learning-ojs3.2-jm-settings-journal-sections-restrict.png)
 
 If this checkbox is checked for all sections, authors will not be able to submit to the journals. Authors who select New Submission from their dashboards will now see the message "This journal is not accepting submissions at this time."
 
-![[Screenshot example of message displayed on a journal New Submission page.](./assets/learning-ojs3.1-jm-settings-journal-not-accepting-submissions.png)
+![An example of message displayed on a journal New Submission page.](./assets/learning-ojs3.1-jm-settings-journal-not-accepting-submissions.png)
 
 ### Order Sections
 
 When you have more than one section created, you will see an Order link. Use that to reorder how those sections display on your journal website.
 
-![Screenshot of list of available sections from top to bottom of page in OJS dashboard.](./assets/learning-ojs3.2-jm-settings-journal-sections-order.png)
+![A list of available sections from top to bottom of page in OJS dashboard.](./assets/learning-ojs3.2-jm-settings-journal-sections-order.png)
 
 Hit the **Done** button when you are finished.
 
@@ -131,6 +131,7 @@ In OJS 3.1.2 you can create Categories to organize your articles into thematic c
 ![OJS dashboard view of Journal Settings submenu Categories with links for Order and Add a Category and editable list of current categories.](./assets/learning-ojs3.1-categories-menu.png)
 
 To create a new category:
+
 * Click Add Category
 * Enter a name for your category that will be displayed to readers
 * Enter a path for the category’s URL on your site
@@ -139,14 +140,16 @@ To create a new category:
 * Optionally add an image which will appear at the top of the category’s page
 * Click Save
 
-![Screenshot of new window for entering category information in text fields and selecting category options.](./assets/learning-ojs3.1-create-category.png)
+![A new window for entering category information in text fields and selecting category options.](./assets/learning-ojs3.1-create-category.png)
 
 To edit a category:
+
 * Click the name of the category you want to edit
 * Make the changes
 * Click OK
 
 To remove a category:
+
 * Click the blue arrow next to the category you want to remove
 * Click the Remove button that appears below
 * Confirm that you want to remove the category

--- a/learning-ojs/3.2/en/reviewing.md
+++ b/learning-ojs/3.2/en/reviewing.md
@@ -7,13 +7,13 @@ version: 3.2
 
 As a reviewer, you will learn of the review request via email or by checking your dashboard:
 
-![Screenshot of assigned submissions queue in reviewer dashboard](./assets/learning-ojs-3-rev-dashboard.png)
+![The assigned submissions queue in reviewer dashboard](./assets/learning-ojs-3-rev-dashboard.png)
 
 From the My Assigned list, find the title and Review link. Notice the lack of any author information in this double-blind peer review process.
 
 Selecting the Review link will take you to the first review step in the submission record, which is much more limited than the editor’s view, and contains no author information.
 
-![Screenshot of a review request](./assets/learning-ojs-3-rev-step1.png)
+![A review request](./assets/learning-ojs-3-rev-step1.png)
 
 This first step consists of the following sections:
 
@@ -25,11 +25,11 @@ This first step consists of the following sections:
 
 Further down the screen, you will find additional information.
 
-![Screenshot showing more of the review request screen](./assets/learning-ojs-3-rev-step1-3.png)
+![More of the review request screen](./assets/learning-ojs-3-rev-step1-3.png)
 
 The **View All Submission Details** link will open a window with additional information, including all of the non-author metadata:
 
-![Screenshot of the view all submission details screen](./assets/learning-ojs-3-rev-step1-2.png)
+![The view all submission details screen](./assets/learning-ojs-3-rev-step1-2.png)
 
 Note that none of these fields are editable by the reviewer, and are only provided to help you conduct a thorough review.
 
@@ -37,15 +37,15 @@ Close this window and move further down the screen. From here you can see the Re
 
 From here, you can decline or accept the review. If you decline, you will be dropped from the process. If you accept, you will move to review step 2, where you would be able to read any reviewer guidelines provided by the journal.
 
-![Screenshot of reviewer guidelines](./assets/learning-ojs-3-rev-step2.png)
+![The reviewer guidelines](./assets/learning-ojs-3-rev-step2.png)
 
 Hit **Continue** to move to step 3. From here you can download a copy of the review files and enter your review comments. The first window is for comments to the editor and the author; the second window is just for the editor.
 
-![Screenshot of the download and review tab](./assets/learning-ojs-3-rev-step3.png)
+![The download and review tab](./assets/learning-ojs-3-rev-step3.png)
 
 Once you have read the paper and added your comments, scroll down the page to optionally upload a marked up copy of the review file (remember to strip any personal identification from the file before uploading it).
 
-![Screenshot of upload reviewer files and review recommendation drop down](./assets/learning-ojs-3-rev-step3-1.png)
+![The upload reviewer files and review recommendation drop down](./assets/learning-ojs-3-rev-step3-1.png)
 
 Next, you must then make your recommendation using the dropdown menu.
 
@@ -65,10 +65,10 @@ Your choices include:
 
 Finally, hit the Submit Review button to complete your task. You’ll be asked to confirm.
 
-![Screenshot of confirmation screen to submit review](./assets/learning-ojs-3-rev-step3-2.png)
+![The confirmation screen to submit review](./assets/learning-ojs-3-rev-step3-2.png)
 
 Hit OK. You will be taken to the final confirmation screen thanking you for your work.
 
-![Screenshot of review submitted completion screen](./assets/learning-ojs-3-rev-step4.png)
+![The review submitted completion screen](./assets/learning-ojs-3-rev-step4.png)
 
 That's it! The review is now complete.

--- a/learning-ojs/en/editorial-workflow.md
+++ b/learning-ojs/en/editorial-workflow.md
@@ -104,7 +104,7 @@ This section includes a list of all submissions, without being organized into qu
 
 This section includes a list of all submissions either declined or already published by the journal. Declined submissions may be deleted from the list of archived submissions. Deleting a declined submission will completely remove the submission and all submission files from your journal.
 
-![Screenshot of the list of archived submissions with the option to delete submissions.](./assets/ojs-3.3-sub-delete.png)
+![The list of archived submissions with the option to delete submissions.](./assets/ojs-3.3-sub-delete.png)
 
 ### Demonstration Submission
 
@@ -165,7 +165,7 @@ Use the Notes tab to also view or add any editorial notes.
 
 **Preview**:  See how the submission will look when published with its current metadata and Galley files by clicking Preview.
 
-![Screenshot of Preview feature that shows how an article will look when published](./assets/learning-ojs-3-ed-preview.png)
+![The preview feature that shows how an article will look when published](./assets/learning-ojs-3-ed-preview.png)
 
 **Metadata**: Where you can view and revise the submission metadata. In OJS 3.2 and later, users can be granted permission to revise certain submission metadata at any stage of the workflow.
 
@@ -637,7 +637,7 @@ Outside of OJS, they will do the copyediting work.
 
 To check the submission metadata, click from the Workflow tab to the Production tab.
 
-![Screenshot of article record's Publication tab with metadata fields](./assets/learning-ojs-3-ce-copyediting-metadata.png)
+![An article record's Publication tab with metadata fields](./assets/learning-ojs-3-ce-copyediting-metadata.png)
 
 This would include checking the article title, abstract, contributor names, keywords, etc.
 

--- a/learning-ojs/en/introduction.md
+++ b/learning-ojs/en/introduction.md
@@ -53,19 +53,19 @@ There are some changes to the dashboard interface and navigation menus for logge
 
 Journal Managers, Editors, Reviewers, Authors, and others who log in may notice a change in the main navigation menu on the left side. In 3.3, only users in roles who have access to the Settings menus (Journal Managers and Editors) will see the left-hand navigation menu. There are also additional menu links for Issues, Announcements, and Payments, and some of the menu links have moved.
 
-![Screenshot of the dashboard that Journal Managers see when logged in](./assets/learning-ojs-3.3-navigation-menu-dashboard-jm.png)
+![The dashboard that Journal Managers see when logged in](./assets/learning-ojs-3.3-navigation-menu-dashboard-jm.png)
 
 Users in other roles will not see the menu because they can only access the Submissions part of the menu.
 
-![Screenshot of the dashboard that Authors see when logged in](./assets/learning-ojs-3.3-navigation-menu-dashboard-author.png)
+![The dashboard that Authors see when logged in](./assets/learning-ojs-3.3-navigation-menu-dashboard-author.png)
 
 A user can now access their user profile and select a language on multilingual journals by clicking the person icon on the top right corner.
 
-![Screenshot of the menu where users can edit their profile and select a language](./assets/learning-ojs-3.3-navigation-menu-dashboard-user-menu.png)
+![The menu where users can edit their profile and select a language](./assets/learning-ojs-3.3-navigation-menu-dashboard-user-menu.png)
 
 The link from the dashboard to the public journal site home page has moved. A Journal Manager or Editor can now view the public journal site by clicking the name of the journal that appears on the top left corner of the page. For multi-journal installations, you can click the site map symbol on the top left corner of the page and then a list of journals in the installation will appear below and you can select the site you want to view.
 
-![Screenshot of the link to view the public journal site](./assets/learning-ojs-3.3-navigation-menu-dashboard-view-journal.png)
+![The link to view the public journal site](./assets/learning-ojs-3.3-navigation-menu-dashboard-view-journal.png)
 
 ### Editorial Workflow
 

--- a/learning-ojs/en/journal-setup.md
+++ b/learning-ojs/en/journal-setup.md
@@ -94,7 +94,7 @@ Submissions can also be disabled for individual sections. This can be done in in
 
 You can check off "Will not be included in the indexing of the journal" for sections that contain front matter, back matter, and anything else that might clutter the search index unnecessarily.
 
-![Screenshot of window for entering Word Count, Review Form, and Section Options.](./assets/learning-ojs3.3-section-options.png)
+![A window for entering Word Count, Review Form, and Section Options.](./assets/learning-ojs3.3-section-options.png)
 
 **Identify items published in this section as a\(n\)**: This is used by some systems. Note that it is not a required field.
 
@@ -106,7 +106,7 @@ Hit the **Save** button to save your changes and return to the Sections page.
 
 From the sections page, select the Create Section link to open a blank window, exactly the same as the window used for editing a section described above.
 
-![Screenshot of new window for entering section information in text fields and selecting section options.](./assets/learning-ojs-3.2-settings-website-settings-sections-create.png)
+![A new window for entering section information in text fields and selecting section options.](./assets/learning-ojs-3.2-settings-website-settings-sections-create.png)
 
 Fill in the details and hit Save to record your work.
 
@@ -114,7 +114,7 @@ Fill in the details and hit Save to record your work.
 
 Each section allows to restrict submissions by checking the "Items can only be submitted by Editors and Section Editors" checkbox.
 
-![Screenshot of list of options for restricting a section. Items can be selected from list by checking the box to the left of the item.](./assets/learning-ojs3.2-jm-settings-journal-sections-restrict.png)
+![The list of options for restricting a section. Items can be selected from list by checking the box to the left of the item.](./assets/learning-ojs3.2-jm-settings-journal-sections-restrict.png)
 
 If this checkbox is checked for all sections, authors will not be able to submit to the journals. Authors who select New Submission from their dashboards will now see the message "This journal is not accepting submissions at this time."
 
@@ -124,7 +124,7 @@ If this checkbox is checked for all sections, authors will not be able to submit
 
 When you have more than one section created, you will see an Order link. Use that to reorder how those sections display on your journal website.
 
-![Screenshot of list of available sections from top to bottom of page in OJS dashboard.](./assets/learning-ojs3.2-jm-settings-journal-sections-order.png)
+![A list of available sections from top to bottom of page in OJS dashboard.](./assets/learning-ojs3.2-jm-settings-journal-sections-order.png)
 
 Hit the **Done** button when you are finished.
 
@@ -144,7 +144,7 @@ To create a new category:
 * Optionally add an image which will appear at the top of the category’s page
 * Click Save
 
-![Screenshot of new window for entering category information in text fields and selecting category options.](./assets/learning-ojs3.1-create-category.png)
+![A new window for entering category information in text fields and selecting category options.](./assets/learning-ojs3.1-create-category.png)
 
 To edit a category:
 

--- a/learning-ojs/en/reviewing.md
+++ b/learning-ojs/en/reviewing.md
@@ -7,13 +7,13 @@ version: 3.3
 
 As a reviewer, you will learn of the review request via email or by checking your dashboard:
 
-![Screenshot of assigned submissions queue in reviewer dashboard](./assets/learning-ojs-3-rev-dashboard.png)
+![The assigned submissions queue in reviewer dashboard](./assets/learning-ojs-3-rev-dashboard.png)
 
 From the My Assigned list, find the title and Review link. Notice the lack of any author information in this Anonymous Reviewer/Anonymous Author peer review process.
 
 Selecting the Review link will take you to the first review step in the submission record, which is much more limited than the editor’s view, and contains no author information.
 
-![Screenshot of a review request](./assets/learning-ojs-3-rev-step1.png)
+![A review request](./assets/learning-ojs-3-rev-step1.png)
 
 This first step consists of the following sections:
 
@@ -25,11 +25,11 @@ This first step consists of the following sections:
 
 Further down the screen, you will find additional information.
 
-![Screenshot showing more of the review request screen](./assets/learning-ojs-3-rev-step1-3.png)
+![More of the review request screen](./assets/learning-ojs-3-rev-step1-3.png)
 
 The **View All Submission Details** link will open a window with additional information, including all of the non-author metadata:
 
-![Screenshot of the view all submission details screen](./assets/learning-ojs-3-rev-step1-2.png)
+![The view all submission details screen](./assets/learning-ojs-3-rev-step1-2.png)
 
 Note that none of these fields are editable by the reviewer, and are only provided to help you conduct a thorough review.
 
@@ -37,15 +37,15 @@ Close this window and move further down the screen. From here you can see the Re
 
 From here, you can decline or accept the review. If you decline, you will be dropped from the process. If you accept, you will move to review step 2, where you would be able to read any reviewer guidelines provided by the journal.
 
-![Screenshot of reviewer guidelines](./assets/learning-ojs-3-rev-step2.png)
+![The reviewer guidelines](./assets/learning-ojs-3-rev-step2.png)
 
 Hit **Continue** to move to step 3. From here you can download a copy of the review files and enter your review comments. The first window is for comments to the editor and the author; the second window is just for the editor.
 
-![Screenshot of the download and review tab](./assets/learning-ojs-3-rev-step3.png)
+![The download and review tab](./assets/learning-ojs-3-rev-step3.png)
 
 Once you have read the paper and added your comments, scroll down the page to optionally upload a marked up copy of the review file (remember to strip any personal identification from the file before uploading it).
 
-![Screenshot of upload reviewer files and review recommendation drop down](./assets/learning-ojs-3-rev-step3-1.png)
+![The upload reviewer files and review recommendation drop down](./assets/learning-ojs-3-rev-step3-1.png)
 
 Next, you must then make your recommendation using the dropdown menu.
 
@@ -65,10 +65,10 @@ Your choices include:
 
 Finally, hit the Submit Review button to complete your task. You’ll be asked to confirm.
 
-![Screenshot of confirmation screen to submit review](./assets/learning-ojs-3-rev-step3-2.png)
+![The confirmation screen to submit review](./assets/learning-ojs-3-rev-step3-2.png)
 
 Hit OK. You will be taken to the final confirmation screen thanking you for your work.
 
-![Screenshot of review submitted completion screen](./assets/learning-ojs-3-rev-step4.png)
+![The review submitted completion screen](./assets/learning-ojs-3-rev-step4.png)
 
 That's it! The review is now complete.

--- a/learning-omp/en/role-specific-workflows.md
+++ b/learning-omp/en/role-specific-workflows.md
@@ -58,7 +58,7 @@ Press **Complete** followed by **Save and Continue**.
 
 You will need to enter the following metadata regarding your manuscript. Items marked with the red asterisk are a mandatory part of the submission.
 
-![Image of the metadata form under the Catalog tab of the submission process.](./assets/learning-omp_role-specific-workflow_auth-subm-5.png)
+![The metadata form under the Catalog tab of the submission process.](./assets/learning-omp_role-specific-workflow_auth-subm-5.png)
 
 Enter your manuscript’s Title, Subtitle, Abstract, List of Contributors, Chapters, Additional Refinements Subjects, and Keywords as applicable.
 
@@ -154,12 +154,13 @@ All author, reviewer, and editor revision files are available from the Revisions
 Once all the reviews are in, you must make a decision on the submission. You may select one of the following:
 
 * Request Revisions, in which case the author will be able to modify their submission information and/or upload revised submission files
-* Decline Submission, at which point the submission will be archived and the author notified. A declined submission can be reverted 
+* Decline Submission, at which point the submission will be archived and the author notified. A declined submission can be reverted
 * Accept Submission, at which point the submission will enter the Editorial stage
 
 These selections are found on the right panel in the Internal Review menu.
 
 #### Reversing a declined decision
+
 OMP 3.3 allows Press Editors to to reverse a declined decision in the submission and review stages. After a declined decision is reverted, the submission is restored to its previous stage and review round if active. 
 
 ## Copyediting Workflow
@@ -338,6 +339,7 @@ __Audience Range Qualifier__
 __Audience Range__
 
 ##### Additional Resources
+
 * [How do Audience / Subject / Audience Range work together to help librarians and other professionals select products?](https://booknetcanada.atlassian.net/wiki/spaces/UserDocs/pages/16449595/How+do+Audience+Subject+Audience+Range+work+together+to+help+librarians+and+other+professionals+select+products)
 * [ONIX](https://booknetcanada.atlassian.net/wiki/spaces/UserDocs/pages/1378909/ONIX)
 * [Thema Basics: Subject Categories, Qualifier Codes, National Qualifier Lists](https://booknetcanada.atlassian.net/wiki/spaces/UserDocs/pages/8257659/Thema+Basics+Subject+Categories+Qualifier+Codes+National+Qualifier+Lists#ThemaBasics:SubjectCategories,QualifierCodes,NationalQualifierLists-SubjectCategoriesvsQualifierCodes)
@@ -357,7 +359,6 @@ In order to save you will need to fill all the required fields (marked with an a
 To edit or delete a representative, click the blue arrow beside the name.
 
 ![The representatives list with expanded options menu including edit/delete options.](./assets/learning-omp3.2-workflow-production-representative-3.png)
-
 
 #### Publication Dates
 

--- a/learning-ops/en/editorial-workflow.md
+++ b/learning-ops/en/editorial-workflow.md
@@ -23,7 +23,7 @@ This chapter explains the steps in the editorial workflow for Authors, Moderator
 All active and archived (published or declined) submissions for the preprint server will
 appear in the Submissions dashboard.
 
-![Screenshot of OPS submission dashboard as Preprint Manager](./assets/learning-ops3.3-submissions-dashboard.png)
+![The OPS submission dashboard as Preprint Manager](./assets/learning-ops3.3-submissions-dashboard.png)
 
 Which submissions are visible will depend on the role of the logged in user.
 

--- a/learning-ops/en/setup.md
+++ b/learning-ops/en/setup.md
@@ -48,7 +48,7 @@ Multiple sections can be created and multiple moderators can be assigned to each
 
 Instructions on how to create, edit, and manage sections is in [Learning OJS 3](/learning-ojs/en/journal-setup#sections).
 
-![Screenshot of the Create Section Window](./assets/learning-ops3.3-server-settings-create-section.png)
+![The Create Section Window](./assets/learning-ops3.3-server-settings-create-section.png)
 
 ### Categories
 
@@ -56,7 +56,7 @@ This area allows for the creation and management of categories, which is another
 
 Instructions on how to create, edit, and manage categories is in [Learning OJS 3](/learning-ojs/en/journal-setup#categories). Here’s an example of what adding a new category looks like:
 
-![Screenshot of the Create Category Window](./assets/learning-ops3.3-server-settings-add-category.png)
+![The Create Category Window](./assets/learning-ops3.3-server-settings-add-category.png)
 
 Another difference between sections and categories is the ability of having sub-categories associated to a parent category, as seen below:
 

--- a/learning-ops/en/statistics.md
+++ b/learning-ops/en/statistics.md
@@ -12,7 +12,7 @@ There are a number of identified improvements that will be made towards statisti
 
 The Preprints section provides a visual display as well as a table format of preprint activity.  The visual graphic can be changed from Monthly or Daily view. While the table format will allow you to filter the Total in ascending or descending order. As well as changed to view Abstract and File activity.
 
-![Screenshot of visual graph and table of the Preprint Report](./assets/learning-ops-statistics-preprints-report.png)
+![The visual graph and table of the Preprint Report](./assets/learning-ops-statistics-preprints-report.png)
 
 There are also a number of filters that can be used including date range and section. The search bar under Preprint Details can be used to search for the activity of a specific preprint manuscript.
 
@@ -20,13 +20,13 @@ There are also a number of filters that can be used including date range and sec
 
 The Editorial activity statistics provides a visual graph and trend table with a summary of the editorial activity for your Server. This can be filtered for a specific date range.
 
-![Screenshot of Editorial Activity Report](./assets/learning-ops3.3-statistics-editorial-report.png)
+![The OJS Editorial Activity Report](./assets/learning-ops3.3-statistics-editorial-report.png)
 
 ## Users
 
 Provides a summary of the number of users registered in your server and by roles.
 
-![Screenshot of User Report](./assets/learning-ops-statistics-users-report.png)
+![The OJS User Report](./assets/learning-ops-statistics-users-report.png)
 
 ## Report Generator
 

--- a/pkp-pn/en/index.md
+++ b/pkp-pn/en/index.md
@@ -37,7 +37,7 @@ To configure the plugin, you will need to be logged in as the Administrator.
 5. Once the plugin has been updated or enabled, click Settings to review and accept the terms of use. The Journal Identifier will automatically be populated.
 6. Click Save
 
-![Image of PKP PN Plugin Screen with Terms of Use checkboxes filled in, automatically populated Journal Identifier field, and Save button](./assets/pkp-pn-terms.png)
+![The PKP PN Plugin Screen with Terms of Use checkboxes filled in, automatically populated Journal Identifier field, and Save button](./assets/pkp-pn-terms.png)
 
 ## Using the Plugin
 
@@ -64,13 +64,13 @@ The reset option for the issue deposit will repackage and send the files to the 
 
 To check the status of the PKP PN plugin, click the blue arrow beside the plugin title followed by Status.
 
-![Image of PKP PN Plugin menu expanded on the Plugin Gallery screen, with an arrow pointing to the Status link](./assets/pkp-pn-status-button.png)
+![The PKP PN Plugin menu expanded on the Plugin Gallery screen, with an arrow pointing to the Status link](./assets/pkp-pn-status-button.png)
 
 The key thing to look for in the PKP PN status page would be the LOCKSS status column. If the preservation of an issue is successful, the LOCKSS status will indicate “**Agreement**,” meaning the whole network agrees that there is a consistent copy of the issue archived.
 
 The status menu will identify the type, type object ID, number of items checked, and various statuses.
 
-![Image of PKP PN Plugin Status screen demonstrating LOCKSS Status parameters for several issues](./assets/pkp-pn-status-menu.png)
+![The PKP PN Plugin Status screen demonstrating LOCKSS Status parameters for several issues](./assets/pkp-pn-status-menu.png)
 
 * **ID**: The deposit's internal database identifier.
 * **Type**: Whether the deposit is an issue or an article. At the moment, only issues are being packaged. Each issue is exported and stored as a zipped Bag. The bag has information about the journal (journal title, ISSN, etc.) and copyright and licensing information about each article in the issue.
@@ -117,7 +117,7 @@ If you want to cease depositing your content in the PKP PN, simply disable the p
 
 ### I’ve enabled the plugin and the Terms of Use aren’t showing up after I click refresh
 
-![Image of an example of Terms of Use not displaying in the PKP PN Plugin setup screen.](./assets/pkp-pn-refresh-terms.png)
+![An example of Terms of Use not displaying in the PKP PN Plugin setup screen.](./assets/pkp-pn-refresh-terms.png)
 
 Check to see that an ISSN has been entered in your [Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#masthead). Once this information is in your journal, it will list the Terms of Use.
 

--- a/pkp-theming-guide/en/theme-options-api.md
+++ b/pkp-theming-guide/en/theme-options-api.md
@@ -4,7 +4,7 @@ Theme options allow you to offer theme-specific configuration settings. They are
 
 Options added to a theme will appear under the theme selection in the Settings > Website > Appearance > Theme  section.
 
-![Screenshot of theme options in backend](theme-options.png)
+![Theme options in the OJS backend](theme-options.png)
 
 ## Add a theme option
 


### PR DESCRIPTION
Following recommended best practices and discussion with @librariam, this PR removes alt-text that starts with "image of" or "screenshot of".