### PR TITLE
Block indexing in search engines for CP guide

### DIFF
--- a/_includes/book/head.html
+++ b/_includes/book/head.html
@@ -10,6 +10,9 @@
 {% if page.url %}
 	<meta property="og:url" content="{{ site.url }}{{ page.url }}">
 {% endif %}
+{% if page.indexed == "exclude" %}
+	<meta name="robots" content="noindex">
+{% endif %}
 <link type="text/css" href="/css/book.css" rel="stylesheet" media="all">
 <link href="https://fonts.googleapis.com/css?family=Roboto:300,300i,400,400i,500,500i,700,700i|Roboto+Mono:400,700" rel="stylesheet">
 <script defer src="https://unpkg.com/smooth-scroll@12.1.5/dist/js/smooth-scroll.polyfills.min.js"></script>

--- a/_includes/book/head.html
+++ b/_includes/book/head.html
@@ -10,7 +10,7 @@
 {% if page.url %}
 	<meta property="og:url" content="{{ site.url }}{{ page.url }}">
 {% endif %}
-{% if page.indexed == "exclude" %}
+{% if page.noindex %}
 	<meta name="robots" content="noindex">
 {% endif %}
 <link type="text/css" href="/css/book.css" rel="stylesheet" media="all">

--- a/coalition-publica/en/README.md
+++ b/coalition-publica/en/README.md
@@ -1,3 +1,6 @@
+---
+indexed: exclude
+---
 # Coalition Publica OJS Integration Guide
 
 This document describes how to prepare your ​Open Journal Systems​ installation for inclusion in Érudit​, as part of the ​Coalition Publica​ initiative. This will involve configuring your OJS installation to deliver JATS data to Érudit.

--- a/coalition-publica/en/README.md
+++ b/coalition-publica/en/README.md
@@ -1,5 +1,5 @@
 ---
-indexed: exclude
+noindex: true
 ---
 # Coalition Publica OJS Integration Guide
 

--- a/coalition-publica/en/requirements.md
+++ b/coalition-publica/en/requirements.md
@@ -1,5 +1,5 @@
 ---
-indexed: exclude
+noindex: true
 ---
 # Requirements
 

--- a/coalition-publica/en/requirements.md
+++ b/coalition-publica/en/requirements.md
@@ -1,3 +1,6 @@
+---
+indexed: exclude
+---
 # Requirements
 
 In order to begin, you must be running ​**Open Journal Systems 3.1.0 or newer**, and preferably OJS 3.1.2+​. You must be able to install plugins, which requires server access or a Site Administrator role. (If you don’t have Site Administrator permissions, you can also request that the required plugins be installed by your Site Administrator or institutional service provider.)

--- a/coalition-publica/en/subscriptions.md
+++ b/coalition-publica/en/subscriptions.md
@@ -1,5 +1,5 @@
 ---
-indexed: exclude
+noindex: true
 ---
 # Subscriptions and Non-Publishing Use of OJS
 

--- a/coalition-publica/en/subscriptions.md
+++ b/coalition-publica/en/subscriptions.md
@@ -1,3 +1,6 @@
+---
+indexed: exclude
+---
 # Subscriptions and Non-Publishing Use of OJS
 
 If you are using OJS to publish content that requires subscription, or if you are using OJS for workflow but not publishing, some additional configuration is required to allow Érudit to access your content. You will also need to be running **OJS 3.1.2.1 or newer**.

--- a/coalition-publica/en/using-jats.md
+++ b/coalition-publica/en/using-jats.md
@@ -1,3 +1,6 @@
+---
+indexed: exclude
+---
 # Using JATS with OJS
 
 Érudit collects metadata from your OJS installation in ​[JATS](https://jats.nlm.nih.gov/)​ XML. JATS is commonly used to publish or index journal articles. However, creating and using JATS effectively can be complex. There are several different ways to work with JATS using OJS.

--- a/coalition-publica/en/using-jats.md
+++ b/coalition-publica/en/using-jats.md
@@ -1,5 +1,5 @@
 ---
-indexed: exclude
+noindex: true
 ---
 # Using JATS with OJS
 

--- a/coalition-publica/fr/README.md
+++ b/coalition-publica/fr/README.md
@@ -1,3 +1,6 @@
+---
+indexed: exclude
+---
 # Coalition Publica guide d'intégration d'application OJS
 
 Ce document décrit les interventions nécessaires sur votre instance ​Open Journal Systems pour être diffusé sur ​Érudit​, dans le cadre de l’initiative ​Coalition Publica​. Il s’agit de configurer votre instance OJS afin de pouvoir transmettre à Érudit vos données au format JATS.

--- a/coalition-publica/fr/README.md
+++ b/coalition-publica/fr/README.md
@@ -1,5 +1,5 @@
 ---
-indexed: exclude
+noindex: true
 ---
 # Coalition Publica guide d'intégration d'application OJS
 

--- a/coalition-publica/fr/requirements.md
+++ b/coalition-publica/fr/requirements.md
@@ -1,3 +1,6 @@
+---
+indexed: exclude
+---
 # Requis techniques
 
 En premier lieu, vous devez opérer une instance **Open Journal Systems 3.1.0 ou plus récente**. Vous devez avoir les permissions requises pour installer les *plugins*, ce qui nécessite des accès au serveur ou un rôle Administrateur. (Si vous n’avez pas les permissions Administrateur vous pouvez demander à votre Administrateur ou hébergeur institutionnel d’installer les *plugins*.)

--- a/coalition-publica/fr/requirements.md
+++ b/coalition-publica/fr/requirements.md
@@ -1,5 +1,5 @@
 ---
-indexed: exclude
+noindex: true
 ---
 # Requis techniques
 

--- a/coalition-publica/fr/subscriptions.md
+++ b/coalition-publica/fr/subscriptions.md
@@ -1,3 +1,6 @@
+---
+indexed: exclude
+---
 # Abonnements et utilisation d’OJS sans publication
 
 Si vous utilisez OJS pour publier du contenu requérant un abonnement ou si vous utilisez OJS pour la gestion éditoriale sans publier, une configuration supplémentaire est nécessaire afin de permettre à Érudit d’accéder à votre contenu. Il est également requis que votre instance OJS soit à la version ​**OJS 3.1.2-1 ou plus récente**​.

--- a/coalition-publica/fr/subscriptions.md
+++ b/coalition-publica/fr/subscriptions.md
@@ -1,5 +1,5 @@
 ---
-indexed: exclude
+noindex: true
 ---
 # Abonnements et utilisation d’OJS sans publication
 

--- a/coalition-publica/fr/using-jats.md
+++ b/coalition-publica/fr/using-jats.md
@@ -1,3 +1,6 @@
+---
+indexed: exclude
+---
 # Utiliser JATS avec OJS
 
 Érudit utilise le format XML standardisé ​[JATS](https://jats.nlm.nih.gov/)​ pour récupérer les articles de votre instance OJS. L’utilisation de JATS est répandue pour la publication et l’indexation d’articles de revue. Toutefois, la création et l’utilisation de JATS peut s’avérer complexe. Il y a plusieurs façons de travailler avec JATS dans le contexte d’OJS.

--- a/coalition-publica/fr/using-jats.md
+++ b/coalition-publica/fr/using-jats.md
@@ -1,5 +1,5 @@
 ---
-indexed: exclude
+noindex: true
 ---
 # Utiliser JATS avec OJS
 

--- a/coalition-publica/index.md
+++ b/coalition-publica/index.md
@@ -1,5 +1,6 @@
 ---
 isBookIndex: true
+indexed: exclude
 ---
 
 # Coalition Publica OJS Guide

--- a/coalition-publica/index.md
+++ b/coalition-publica/index.md
@@ -1,6 +1,6 @@
 ---
 isBookIndex: true
-indexed: exclude
+noindex: true
 ---
 
 # Coalition Publica OJS Guide

--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,18 @@ The base URL, `/<any-book>/en`, should always be the current version so that any
 
 This structure doesn't yet support versioning separate language editions of documents. We can work on that when we need it.
 
+## Block search indexing
+
+To block indexing in search engines, add the following to the frontmatter in each `.md` file in a document:
+
+```
+---
+noindex: true
+---
+```
+
+This will add `<meta name="robots" content="noindex">` to each page.
+
 ## Generate REST API References
 
 The REST API references use [redoc](https://github.com/Redocly/redoc) to generate the human-readable documentation from an OpenAPI json file. To build the REST API references you will need a checkout of the application for the version you wish to generate a reference.


### PR DESCRIPTION
This PR adds the ability to add `<meta name="robots" content="noindex">` to a given page, done by adding `indexed: exclude` in the frontmatter.

This PR adds this functionality to the pages in the Coalition Publica guide, which @emmauhl forwarded from the CP team.