### PR TITLE
Update editorial-workflow.md

### DIFF
--- a/learning-ojs/en/editorial-workflow.md
+++ b/learning-ojs/en/editorial-workflow.md
@@ -27,7 +27,7 @@ Some submission will not pass review and end here. Those that are accepted move 
 
 Your Tasks are available from the top left menu of your Dashboard. Note the number "1" in the image below. This indicates that there is currently 1 task in your list.
 
-![](./assets/learning-ojs3.1-ed-tasks.png)
+![The expanded Tasks menu in OJS.](./assets/learning-ojs3.1-ed-tasks.png)
 
 Tasks provide a quick look at items that need your attention. Bold entries are unread, and unbold entries have been read.
 
@@ -46,7 +46,7 @@ To enable copies of submission acknowledgment email to be sent to the primary co
 3. Check off the box next to “Send a copy to the primary contact, identified in the Journal Settings.” if you wish for a copy to be sent to the primary contact email, and/or
 4. Enter the email you would like to have a copy sent to in the text field.
 
-![](./assets/learning-ojs3.1-configure-submission-notification.png)
+![The Notification of Author Submission settings in OJS.](./assets/learning-ojs3.1-configure-submission-notification.png)
 
 If you want to disable submission acknowledgement emails entirely, you can do so by disabling the *Submission Ack* email template from the list of prepared email templates. To learn more about disabling and enabling email templates, refer to *Disable email templates* in the [Workflow Settings chapter](./settings-workflow).
 
@@ -56,7 +56,7 @@ Users can also change their individual notification settings from their own prof
 
 When you log into your Dashboard, you can find active submissions either from your Tasks, or from one of the queues (My Queue, Unassigned, All Active, and Archives). The counter gives you an overview of how many total items are in each queue.
 
-![](./assets/learning-ojs3.2-ed-dashboard-active.png)
+![The submission dashboard in OJS.](./assets/learning-ojs3.2-ed-dashboard-active.png)
 
 ### My Queue
 
@@ -80,17 +80,17 @@ Some filters allow multiple selections; users can filter by more than one editor
 
 When using multiple filters, the AND condition will be applied between filters. For example, when filtering by Review Stage AND Editor A, only submissions assigned to Editor A in the review stage will be returned.
 
-![](./assets/learning-ojs3.2-ed-dashboard-filter.png)
+![A sample filter applied to the list of submissions.](./assets/learning-ojs3.2-ed-dashboard-filter.png)
 
 Note that you can use the blue arrows to the right of each submission to reveal more details, including how many reviews are outstanding, new discussions, and more. It also reveals buttons to take you to the submission record, view the activity log and notes, and to delete the submission.
 
-![](./assets/learning-ojs3.2-ed-dashboard-active-details.png)
+![A sample of expanded submission details in the dashboard.](./assets/learning-ojs3.2-ed-dashboard-active-details.png)
 
 ### Unassigned
 
 This panel includes submissions added to sections without section editors.
 
-![](./assets/learning-ojs3.1-ed-dashboard-unassigned.png)
+![The Unassigned tab in the Submissions dashboard.](./assets/learning-ojs3.1-ed-dashboard-unassigned.png)
 
 In the above example, there are no unassigned submissions, so the panel is empty.
 
@@ -98,7 +98,7 @@ In the above example, there are no unassigned submissions, so the panel is empty
 
 This section includes a list of all submissions, without being organized into queues.
 
-![](./assets/learning-ojs3.1-ed-dashboard-all-active.png)
+![The All Active tab in the Submissions dashboard.](./assets/learning-ojs3.1-ed-dashboard-all-active.png)
 
 ### Archives
 
@@ -118,13 +118,17 @@ Once you find the submission, you can use the view button to view the submission
 
 **Activity Log & Notes** will bring up the submission's history.
 
-![](./assets/learning-ojs3.1-ed-dashboard-log.png)
+![A sample activity log for a submission](./assets/learning-ojs3.1-ed-dashboard-log.png)
+
+Use the Notes tab to also view or add any editorial notes.
+
+![The Notes tab of the Activity log.](./assets/learning-ojs-3-ed-submissions-notes.png)
 
 ### Submission Record
 
 To view the submission in more detail, select **View Submission** button. This will take you to the submission record.
 
-![](./assets/learning-ojs3.1-ed-dashboard-record.png)
+![A sample submission record.](./assets/learning-ojs3.1-ed-dashboard-record.png)
 
 From here, you can see:
 
@@ -140,28 +144,18 @@ For journals using anonymous review, the author and reviewer (if they were to up
 
 **Submission Status** Once an editor has recorded a decision in one stage of the workflow of OJS 3.2, the recorded decision will appear in place of the decision buttons. Editors will still have the ability to change the recorded decision by clicking, ‘Change Decision’ this will enable the 3 options once again.
 
-![](./assets/learning-ojs3.2_edflow_decisionstatus.png)
+![The Change Decision button in the submission status.](./assets/learning-ojs3.2_edflow_decisionstatus2.png)
 *The screenshot above shows the decision button for MS# 425 prior to a decision being recorded. The screenshot below shows the notification of the recorded decision.*
 
-![](./assets/learning-ojs3.2_edflow_decisionstatus2.png)
+![The "Submission accepted" status of a submission.](./assets/learning-ojs3.2_edflow_decisionstatus_accept.png)
 
 **Participants**: This panel is where you will see the list of participants involved in the submission, including the editor, section editors, and author. Other names (copyeditors, layout editors, etc.) will appear here as they are added in subsequent steps.
-
-In addition, in the blue bar along the top, you can see:
-
-**Activity Log**: Where you can view the history and any notes about the submission.
-
-![](./assets/learning-ojs3.1-ed-dashboard-log.png)
-
-Use the Notes tab to also view or add any editorial notes.
-
-![](./assets/learning-ojs-3-ed-submissions-notes.png)
 
 **Submission Library**: The Submission Library is a general storage area for documents that may include conflict-of-interest forms, galley approval forms, etc. A user can upload the completed form for their manuscript in their Submission Library. The uploaded forms will also be available to other participants (with the exception of Reviewers) assigned throughout the editorial or production workflow to edit or re-upload new versions.
 
 **Document Library**: Users throughout the editorial workflow will be able to access all the files in the Publisher Library (see [Workflow Settings chapter](./settings-workflow.md)) made available by the Journal Manager or Editor through opening the Submission Library and clicking "View Document Library".
 
-![](./assets/learning-ojs3.1-jm-settings-workflow-sublib1.png)
+![The location of the View Document Library button in the Submission Library panel.](./assets/learning-ojs3.1-jm-settings-workflow-sublib1.png)
 
 **Preview**:  See how the submission will look when published with its current metadata and Galley files by clicking Preview.
 
@@ -169,44 +163,44 @@ Use the Notes tab to also view or add any editorial notes.
 
 **Metadata**: Where you can view and revise the submission metadata. In OJS 3.2 and later, users can be granted permission to revise certain submission metadata at any stage of the workflow.
 
-![](./assets/learning-ojs3.1-ed-dashboard-record-metadata.png)
+![The Metadata tab of a submission.](./assets/learning-ojs3.1-ed-dashboard-record-metadata.png)
 
 ### Granting Author permissions
 
-In OJS 3.2, editors can grant access to allow authors to make metadata changes.
+As of OJS 3.2, editors can grant access to allow authors to make metadata changes.
 There are two ways editors can grant this type of access.
 
 **Global permission**- will grant all users with the role ‘author’ permission to make metadata changes.
 
 To enable this, go to Users & Roles > Roles. Click the blue arrow beside the ‘Author’ then click edit.
 
-![](./assets/learning-ojs3.2-editorial-workflow-author-edit.png)
+![The location of the Edit button under the Author role.](./assets/learning-ojs3.2-editorial-workflow-author-edit.png)
 
 Under Role Options, enable ‘Permit submission metadata edit.’ then click OK.
 
-![](./assets/learning-ojs3.2-editorial-workflow-author-editmenu.png)
+![The "Permit submission metadata edit" checkbox in the role editing window.](./assets/learning-ojs3.2-editorial-workflow-author-editmenu.png)
 
 **Limited Permission** - will grant registered authors (typically a single author) permission to only make changes at certain stages of the editorial workflow.
 
 To allow an author to change the metadata at a specific stage of the workflow, click on the workflow stage (ie., Submission, Review, Copyediting, or Production).
 
-Under the participant’s list, click the arrow beside the author’s name followed by Edit.
+Under the participants list, click the arrow beside the author’s name followed by Edit.
 
-![](./assets/learning-ojs3.2-editorial-workflow-edit-participant.png)
+![The location of the Edit button for a participant in the participants list.](./assets/learning-ojs3.2-editorial-workflow-edit-participant.png)
 
 Under Permissions, enable ‘Allow this person to edit publication details.’ followed by OK.
 
-![](./assets/learning-ojs3.2-editorial-workflow-edit-grantpermission.png)
+![The "Allow this person to edit publication details" checkbox in the Edit Assignment window.](./assets/learning-ojs3.2-editorial-workflow-edit-grantpermission.png)
 
 Once the author has been granted access to made edits they will be able to make changes to the following sections on the Publication tab: Title & Abstract, Contributors, and Metadata.
 
-![](./assets/learning-ojs3.2-editorial-workflow-edit-publicationmenu.png)
+![The sections available for authors to edit highlighted in the Publication tab.](./assets/learning-ojs3.2-editorial-workflow-edit-publicationmenu.png)
 
 ### Assigning the Submission
 
 Depending on how you have your sections configured, some new submissions may come in unassigned. If this is the case, the next step is to assign an editor or section editor. To do so, select the _Assign_ link in the **Participants** panel.
 
-![](./assets/learning-ojs-3-ed-submissions-add-participant.png)
+![The Add Participants window.](./assets/learning-ojs-3-ed-submissions-add-participant.png)
 
 You will have the option to locate a user by role, choose an individual, and send them a message requesting their assistance.
 
@@ -214,7 +208,7 @@ You will have the option to locate a user by role, choose an individual, and sen
 
 Hit the **OK** button to make the assignment and send the message.
 
-![](./assets/learning-ojs3.1-ed-dashboard-record-assign.png)
+![The added participants name shown in the participants list.](./assets/learning-ojs3.1-ed-dashboard-record-assign.png)
 
 > Note the new Pre-Review Discussion that was automatically created as part of the assignment.
 
@@ -230,17 +224,17 @@ Although in this example, the editor assigned a section editor, it would also be
 
 Once the editor has selected an action, the submission status will change and the action buttons will be disabled.
 
-![](./assets/learning-ojs3.2_edflow_decisionstatus2.png)
+![The location of the Change Decision button of a submission.](./assets/learning-ojs3.2_edflow_decisionstatus2.png)
 
 ### Section Editor
 
 Now that the Section Editor has been assigned, they can login and view their dashboard. The submission can be found at the top of the My Assigned queue.
 
-![](./assets/learning-ojs3.1-se-dashboard.png)
+![The My Assigned queue of a Section Editor with assigned submissions.](./assets/learning-ojs3.1-se-dashboard.png)
 
 Clicking on the article title opens the full submission record.
 
-![](./assets/learning-ojs3.1-se-record.png)
+![A sample submission record.](./assets/learning-ojs3.1-se-record.png)
 
 #### Accepting the Assignment
 
@@ -254,7 +248,7 @@ If the Section Editor has any questions for the author, they can use the Pre-Rev
 
 Once the Section Editor is satisfied that the submission is appropriate for the journal, they can select the **Send to Review** button to move the submission to the next stage.
 
-![](./assets/learning-ojs3.1-se-record-sendReview.png)
+![The Send to Review confirmation window.](./assets/learning-ojs3.1-se-record-sendReview.png)
 
 Keep the files that are to be reviewed checked off.
 
@@ -264,7 +258,7 @@ Keep the files that are to be reviewed checked off.
 
 When the submission enters the Review Stage, a notification indicates that Reviewers need to be assigned.
 
-![](./assets/learning-ojs3.1-se-record-revstage.png)
+![The "Waiting for reviewers to be assigned" notification.](./assets/learning-ojs3.1-se-record-revstage.png)
 
 > Note: In the screenshot above, we see the Section Editor's view. Notice the limited Action buttons \(only Make Recommendation is available\). If we were logged in as an Editor, we would see more Action buttons \(Request Revision, Accept Submission, Decline Submission\).
 
@@ -272,13 +266,13 @@ From the Reviewers panel, you can select Add Reviewer to assign a new Reviewer.
 
 This opens a new window, where Reviewers are listed and can be selected one at a time.
 
-![Locate reviewer screenshot OJS 3.1.2](./assets/learning-ojs-3.1.2-locate-reviewer.png)
+![The Locate a Reviewer window listing all Reviewers.](./assets/learning-ojs-3.1.2-locate-reviewer.png)
 
 Clicking on the blue arrow reveals more information about their review history, including how many active reviews they are currently assigned, how many reviews they have completed or declined, etc. If the user has added a Biography or Reviewing Interests, this information will be displayed here.
 
 Additionally, a Journal Editor can add an Editorial Note about the reviewer in their profile under Users & Roles > Users. This note will appear in the reviewer details on the Add Reviewer screen, but will not be visible to the reviewer or to the public.
 
-![Reviewer details screenshot OJS 3.1.2](./assets/learning-ojs-3.1.2-add-reviewer.png)
+![A sample of expanded reviewer details with review history and notes.](./assets/learning-ojs-3.1.2-add-reviewer.png)
 
 In OJS releases 3.0 to 3.1.0, you cannot assign a user to review a submission if they are also an editor of the submission.  If you do, the editor will no longer be able to access the submission after they submit their review, in order to maintain the principles of anonymous peer review. However, starting with OJS 3.1.1, you can assign a user to review a submission if they are also an editor of the submission.
 
@@ -294,7 +288,7 @@ For this demonstration, we will pick Adela as our Reviewer and hit the **Select 
 
 This initiates a new window with a message for the Reviewer.
 
-![](./assets/learning-ojs3.1-se-record-revstage-revreq.png)
+![The Add Reviewer screen with email notification template.](./assets/learning-ojs3.1-se-record-revstage-revreq.png)
 
 You can revise any of the prepared text.
 
@@ -302,7 +296,7 @@ If you are using an Anonymous Review method, ensure that the files you send to t
 
 Further down the form, you will see the additional details that are sent to the Reviewer including title, abstract, important dates, and a link to the files to be reviewed.
 
-![](./assets/learning-ojs-3-ed-rev-add-4.png)
+![Review details include type and due date settings.](./assets/learning-ojs-3-ed-rev-add-4.png)
 
 By default, Reviewers will be provided with an extended text box to type in their comments. However, the Journal Manager can create Review Forms in [**Workflow Settings &gt; Review**](./settings-workflow#review) to ask more focused questions. If you would like the Reviewer to fill out a review form, select it under **Review Form**.
 
@@ -310,51 +304,51 @@ Hit the **Add Reviewer** button to send the message and assign the Reviewer.
 
 Back on the Review Stage, we can see the Reviewer is now listed.
 
-![](./assets/learning-ojs-3-ed-rev-reviewer-added.png)
+![The newly added Reviewer seen in the Review Stage.](./assets/learning-ojs-3-ed-rev-reviewer-added.png)
 
 You can make additional changes using the blue arrow toggle next to the Reviewer's name.
 
-![](./assets/learning-ojs-3-ed-rev-reviewer-added-2.png)
+![Expanded reviewer details and options.](./assets/learning-ojs-3-ed-rev-reviewer-added-2.png)
 
 **Review Details**: Provides details on the review.
 
-![](./assets/learning-ojs-3-ed-rev-reviewer-review-details.png)
+![The Review Details window.](./assets/learning-ojs-3-ed-rev-reviewer-review-details.png)
 
 **Email Reviewer**: Allows you to send a message to the Reviewer.
 
-![](./assets/learning-ojs-3-ed-rev-reviewer-email-reviewer.png)
+![The Email Reviewer window.](./assets/learning-ojs-3-ed-rev-reviewer-email-reviewer.png)
 
 **Edit Review**: Allows you to change the review dates and files.
 
-![](./assets/learning-ojs-3-ed-rev-reviewer-edit-review.png)
+![The Edit Review window.](./assets/learning-ojs-3-ed-rev-reviewer-edit-review.png)
 
 **Unassign Reviewer**: Allows you to unassign the Reviewer.
 
-**Cancel Review Request**: Starting in OJS 3.2, you can cancel a review request. This may be necessary when a reviewer has not responded to a review request or accepted to do a review but never delivered.
+**Cancel Review Request**: As of OJS 3.2, you can cancel a review request. This may be necessary when a reviewer has not responded to a review request or accepted to do a review but never delivered.
 
-![Cancel reviewer option](./assets/learning-ojs-3.2-cancel-reviewer.png)
+![The Cancel Reviewer option in the expanded Reviewer options.](./assets/learning-ojs-3.2-cancel-reviewer.png)
 
 Cancelling a review request will permit you to send a template email to the reviewer. The request will then show up in the editor's reviewer list as "cancelled".
 
-![Request cancelled](./assets/learning-ojs-3.2-reviewer-cancelled.png)
+![A sample review request marked "Request cancelled".](./assets/learning-ojs-3.2-reviewer-cancelled.png)
 
 Cancelled review will be recorded in reviewer stats that you can see when selecting a reviewer.
 
-![Cancelled requests in reviewer stats](./assets/learning-ojs-3.2-cancelled-reviews-tracker.png)
+![Cancelled requests as seen in a reviewer's stats.](./assets/learning-ojs-3.2-cancelled-reviews-tracker.png)
 
 **Review Discussion**: Review Discussion is another way for you to contact a reviewer. In a review discussion, you have the option to attach files.
 
 To start a discussion, click ‘Add Discussion.’
 
-![](./assets/learning-ojs3.2-rev-contact2.png)
+![The location of the Add Discussion button.](./assets/learning-ojs3.2-rev-contact2.png)
 
 You will then select the reviewer(s) you would like to start a discussion with.
 
-![](./assets/learning-ojs3.2-rev-contact3.png)
+![The list of reviewers to select for discussion.](./assets/learning-ojs3.2-rev-contact3.png)
 
 **History**: Provides a brief history of the review.
 
-![](./assets/learning-ojs-3-ed-rev-review-history.png)
+![The review History window.](./assets/learning-ojs-3-ed-rev-review-history.png)
 
 At this point, we could add additional Reviewers, and then wait for their recommendations to come in.
 
@@ -373,19 +367,19 @@ The review type will be automatically selected based on what has been configured
 
 The author or editor must ensure that metadata from the manuscript file is removed in Anonymous Reviewer/Anonymous Author. See [Removing Identifying Information](#removing-identifying-information) for more information.
 
-*Reviewer*: The reviewer will not be able to see the author(s) in their reviewer’s queue if the editor has selected Anonymous Reviewer/Anonymous Author. All identifying information in the metadata of the submission details is automatically removed by the system.
+*Reviewer*: The reviewer will not be able to see the author(s) in their reviewer’s queue if the editor has selected Anonymous Reviewer/Anonymous Author. All identifying information in the metadata of the submission details is automatically removed by the system, as seen in the example below.
 
-![](./assets/learning-ojs3.1-ed-rev-anon1.png)
+![A sample of the metadata a reviewer will see in a double anonymous review - no identifying information is included.](./assets/learning-ojs3.1-ed-rev-anon1.png)
 
 At the end of a review, if a reviewer chooses to upload a review file they should remove all identifying information before uploading it to the system. See [Removing Identifying Information](#removing-identifying-information) for more information.
 
 *Author*: No identifying information regarding the reviewer will be visible to the author within their manuscript view.
 
-![](./assets/learning-ojs3.1-ed-rev-anon2.png)
+![A sample of what the author will see after their submission is reviewed - no identifying information is included.](./assets/learning-ojs3.1-ed-rev-anon2.png)
 
-*Editors Decision*: The decision email sent to the author(s) at the end of a review will have generic titles of the reviewers.
+*Editor's Decision*: The decision email sent to the author(s) at the end of a review will have generic titles of the reviewers.
 
-![](./assets/learning-ojs3.1-ed-rev-anon3.png)
+![A sample decision email identifying the reviewer only as "Reviewer A".](./assets/learning-ojs3.1-ed-rev-anon3.png)
 
 **Anonymous Reviewer/Disclosed Author**: Reviewer identity is kept anonymous from the author(s). The reviewers can see the author details.
 
@@ -393,17 +387,17 @@ At the end of a review, if a reviewer chooses to upload a review file they shoul
 
 *Author*: No identifying information regarding the reviewer will be available within their manuscript view.
 
-![](./assets/learning-ojs3.1-ed-rev-anon2.png)
+![A sample of what the author will see after their submission is reviewed - no identifying information is included.](./assets/learning-ojs3.1-ed-rev-anon2.png)
 
 *Editors Decision*: The decision email sent to the author(s) at the end of a review will have generic titles of the reviewers.
 
-![](./assets/learning-ojs3.1-ed-rev-anon3.png)
+![A sample decision email identifying the reviewer only as "Reviewer A".](./assets/learning-ojs3.1-ed-rev-anon3.png)
 
 ### Removing Identifying Information
 
 While OJS has a number of built-in functions for anonymous reviews, additional steps may need to be taken outside of the platform to ensure Anonymous Reviewer/Anonymous Author. A submission file may have information that could identify the authors' identity within the document properties.
 
-![](./assets/learning-ojs3.1-ed-rev-anon4.png)
+![A sample of a document whose author is visible within the document properties.](./assets/learning-ojs3.1-ed-rev-anon4.png)
 
 Authors may also include their name within the article, footnotes, or references, in which case the editor will have to remove it prior to sending for review. Alternatively, authors can be asked to redact their names from the submission file, with "Author" and year used in the references and footnotes instead of the authors' name, article title, etc., prior to submission.
 
@@ -425,32 +419,32 @@ Authors may also include their name within the article, footnotes, or references
 3. Select _Remove personal information from this file on save_
 4. Click _OK_ and save the file
 
-![](./assets/learning-ojs3.1-ed-rev-anon5.png)
+![The "Remove personal information from this file on save" option in Mac OS.](./assets/learning-ojs3.1-ed-rev-anon5.png)
 
 ### Re-uploading the Document
 
 The Journal Managers and Editors are able to re-upload the anonymized document in the Review files by clicking **Upload/Select Files** in the _Review Files_ box.
 
-![](./assets/learning-ojs3.1-ed-rev-anon6.png)
+![The Upload/Select Files button under the Review Files section.](./assets/learning-ojs3.1-ed-rev-anon6.png)
 
 Click **Upload Review File**.
 
-![](./assets/learning-ojs3.1-ed-rev-anon7.png)
+![The Upload Review File button.](./assets/learning-ojs3.1-ed-rev-anon7.png)
 
 Identify the article component and upload the file.
 
-![](./assets/learning-ojs3.1-ed-rev-anon8.png)
+![The article component identification dropdown.](./assets/learning-ojs3.1-ed-rev-anon8.png)
 
 Review Details. It may be helpful to rename the file to the time of re-upload. The file can also be renamed by clicking the arrow on the left side of the file name.
 
-![](./assets/learning-ojs3.1-ed-rev-anon9.png)
+![The Edit button in the expanded menu under the list of review files.](./assets/learning-ojs3.1-ed-rev-anon9.png)
 
 Click Complete and select the file you would like to use for the review.
 
 The file(s) will appear under the initial upload.
 When sending out the review request, ensure that the original manuscript is unselected from the ‘Files To Be Reviewed’.
 
-![](./assets/learning-ojs3.1-ed-rev-anon10.png)
+![Options to toggle which files are included for review.](./assets/learning-ojs3.1-ed-rev-anon10.png)
 
 Select the Review File(s) and click **OK**.
 
@@ -458,19 +452,19 @@ Select the Review File(s) and click **OK**.
 
 Once the Reviewers have completed their work, the Section Editor can see the results in their dashboard. Here they will see notifications that new reviews have been submitted and whether all reviews are in.
 
-![](./assets/learning-ojs-3-ed-rev-responding.png)
+![Sample notification of completed reviews in the Section Editor's dashboard.](./assets/learning-ojs-3-ed-rev-responding.png)
 
 Use the _Read Review_ link in the Reviewers panel to read the comments from the Reviewers, including those for both the Author and Editor as well as for the Editor only.
 
-![](./assets/learning-ojs-3-ed-rev-read-reviews.png)
+![A sample review with comments.](./assets/learning-ojs-3-ed-rev-read-reviews.png)
 
 Select the _Confirm_ link at the bottom of the screen.
 
-![](./assets/learning-ojs-3-ed-rev-thank.png)
+![The Review Confirmed status applied to a review.](./assets/learning-ojs-3-ed-rev-thank.png)
 
 In the Reviewers panel, you can now see a _Thank Reviewer_ link. Choose that to thank the Reviewer.
 
-![](./assets/learning-ojs-3-ed-rev-thank2.png)
+![The Thank Reviewer window.](./assets/learning-ojs-3-ed-rev-thank2.png)
 
 Hit the **Thank Reviewer** button to send the message.
 
@@ -478,7 +472,7 @@ Hit the **Thank Reviewer** button to send the message.
 
 Based on the Reviewer recommendations, you can use the action buttons to make a decision.
 
-![](./assets/learning-ojs-3-ed-rev-decision.png)
+![The various action buttons for making a decision regarding a submission.](./assets/learning-ojs-3-ed-rev-decision.png)
 
 Options include:
 
@@ -494,18 +488,18 @@ In this demonstration, we are going to request that the Author make some minor r
 
 To do so, select the **Request Revisions** button. This results in a new message window.
 
-![](./assets/learning-ojs-3-ed-rev-req-revisions.png)
+![The Request Revisions window.](./assets/learning-ojs-3-ed-rev-req-revisions.png)
 
 You can modify any of the text before sending the message.
 
 Use the **Add Reviews** button to import the Reviewer's comments from the Editor and Author field. Comments in the Editor only field will not be displayed.
 
-![](./assets/learning-ojs-3-ed-rev-req-revisions3.png)
-
 If there are any attachments, such as a marked up file created by a Reviewer, you can attach it here (as long as it has been anonymized).
 In OJS 3.1.2 and later, you can also upload a new file and add it as an attachment.
 
 Hit the **Record Editorial Decision** button to send the message.
+
+![A sample request for revisions with imported comments and options to share files.](./assets/learning-ojs-3-ed-rev-req-revisions3.png)
 
 You must now wait for the Author to respond with their revisions.
 
@@ -513,7 +507,7 @@ You must now wait for the Author to respond with their revisions.
 
 Once the Author has made the revisions, you should receive a message (via email and the Review Discussions panel).
 
-![](./assets/learning-ojs-3-ed-discussion-panel.png)
+![The author's revision found in the Review Discussions panel.](./assets/learning-ojs-3-ed-discussion-panel.png)
 
 You will also see the revised file in the Revisions panel.
 
@@ -521,43 +515,41 @@ At this point, you can download the revised file, check to make sure it is ready
 
 In this case, we're going to inform the Author that we are accepting the revisions. To do so, click on the linked title of the discussion. This will open the discussion box.
 
-![](./assets/learning-ojs-3-ed-discussion-window.png)
+![An expanded discussion.](./assets/learning-ojs-3-ed-discussion-window.png)
 
-Use the **Add Message** button to reply.
+Use the **Add Message** button to reply, either requesting further revision or informing the author that the submission is ready to move on to the next stage.
 
-![](./assets/learning-ojs-3-ed-discussion-window-reply.png)
-
-Another option would be to ask for further revisions, but at this point, we're ready to move on.
+![A sample reply to an author's revisions.](./assets/learning-ojs-3-ed-discussion-window-reply.png)
 
 ### Additional Round of Review
 
 If you would like to put the revised article through another round of review, you can start a second (or third or subsequent) review round after the author revisions have been received.
 
-It is best to start a new round of review **after** an author uploads revised files on the previous round. Creating a New Round of review before the author has uploaded their files could create some confusion as their dashboard (and yours) will default to the new round. The author will, however, be able to switch back to Round 1 to upload their files.
-
-![](./assets/learning-ojs-3-new-round-0.png)
-
-This will also result in having to download the uploaded file from Round 1 and upload it into Round 2 if you opt to go this route.
+It is best to start a new round of review **after** an author uploads revised files on the previous round. Creating a New Round of review before the author has uploaded their files could create some confusion as their dashboard (and yours) will default to the new round. The author will, however, be able to switch back to Round 1 to upload their files. This will also result in having to download the uploaded file from Round 1 and upload it into Round 2.
 
 A new round should **not** be started if you are experiencing any issues with the current round (i.e., unable to record decision, re-invite a declined or removed reviewer).
 
 To start an additional round of review after revised files have been received, click the **New Review Round** tab in the review tab of the manuscript.
 
-![](./assets/learning-ojs-3-new-round-1.png)
+![The New Review Round button in the Review panel](./assets/learning-ojs-3-new-round-1.png)
 
 This will open another menu for you to select which files (provided by the author) to include for the new round of review.
 
-![](./assets/learning-ojs-3-new-round-2.png)
+![File selection options for a newly created review round.](./assets/learning-ojs-3-new-round-2.png)
 
-If there are any additional files you want to make available again from the previous round, this can be done by clicking **Upload/Select Files**. Click **Show files from all accessible workflow stages**.
+If there are any additional files you want to make available again from the previous round, this can be done by clicking **Upload/Select Files**. 
 
-![](./assets/learning-ojs-3-new-round-3.png)
+![The Upload/Select files button in the Review Files window.](./assets/learning-ojs-3-new-round-3.png)
 
-The files available from Round 1 should appear under Submission. The files that appear under Review will only show files uploaded by the author from the previous round (i.e., revised files from Round 1). If you are on Round 3 (and onwards) and require files from Round 1 or 2, you will need to download these to your local desktop and re-upload them using **Upload/Select Files**.
+Check the box next to **Show files from all accessible workflow stages**. The files available from Round 1 should appear under Submission. The files that appear under Review will only show files uploaded by the author from the previous round (i.e., revised files from Round 1). If you are on Round 3 (and onwards) and require files from Round 1 or 2, you will need to download these to your local desktop and re-upload them using **Upload/Select Files**.
 
-![](./assets/learning-ojs-3-new-round-4.png)
+![The list of files for a submission including previous round after the "Show files from all accessible workflow stages" option is enabled.](./assets/learning-ojs-3-new-round-4.png)
 
 Similarly, if there are any additional files authors provide after they upload the resubmission, you can upload them using **Upload/Select Files**.
+
+A new round will be added to the Review panel in the submission dashboard.
+
+![The Round Two tab in the Review panel.](./assets/learning-ojs-3-new-round-0.png)
 
 Once you’re ready to start the new round of review, assign Reviewers as you did in the previous round. You can assign the same reviewers or different reviewers.
 
@@ -567,17 +559,17 @@ These steps can be repeated until a final decision to accept or decline the manu
 
 ### Moving to Copyediting
 
-The submission is now ready to be moved to copyediting. To do so, use the blue **Accept Submission** button.
+The submission is now ready to be moved to copyediting. To do so, use the blue **Send to Copyediting** button.
 
-![](./assets/learning-ojs-3-ed-send-to-copyediting.png)
+![The "Send to Copyediting" button in a submission panel.](./assets/learning-ojs-3-ed-send-to-copyediting.png)
 
 This will open a new window.
 
-![](./assets/learning-ojs-3-ed-accept.png)
+![The Send to Copyediting window including information about the notification of acceptance to be sent to the author.](./assets/learning-ojs-3-ed-accept.png)
 
 Note that if the journal has enabled an article processing charge (APC) to be charged to authors, the option will appear at this stage to notify the author that the payment is due. Selecting "Request publication fee" will prompt a payment notification email to be sent to the author with payment instructions. For information about enabling author fees, please see the [Subscriptions chapter > Payment Types](./subscriptions#payment-types) and [Distribution settings > Enable Payments](./settings-distribution#enable-payments).
 
-![](./assets/learning-ojs3.1-jm-subscriptions-authorfees.png)
+![A sample notification for a journal with APCs enabled.](./assets/learning-ojs3.1-jm-subscriptions-authorfees.png)
 
 Hit the **Record Editorial Decision** button at the bottom of the window.
 
@@ -585,7 +577,7 @@ The submission is automatically moved to the Copyediting stage.
 
 Back on the review tab, you will notice that the status now indicates the submission has been accepted.
 
-![](./assets/learning-ojs3.2_edflow_decisionstatus_accept.png)
+![The "Submission accepted" status of a submission.](./assets/learning-ojs3.2_edflow_decisionstatus_accept.png)
 
 <hr />
 
@@ -593,7 +585,7 @@ Back on the review tab, you will notice that the status now indicates the submis
 
 When a submission is accepted in the Review Stage, it will automatically move to the Copyediting stage.
 
-![](./assets/learning-ojs-3-ed-copyediting.png)
+![The Copyediting stage of a submission.](./assets/learning-ojs-3-ed-copyediting.png)
 
 ### Adding a Copyeditor
 
@@ -601,7 +593,7 @@ When the submission enters the Copyediting Stage, a notification indicates that 
 
 This will open a new window.
 
-![](./assets/learning-ojs-3-ed-copyediting-add.png)
+![The Add Participant window in the Copyediting stage.](./assets/learning-ojs-3-ed-copyediting-add.png)
 
 You can use the role dropdown to choose Copyeditor and hit the **Search** button. This will bring up all Copyeditors.
 
@@ -615,7 +607,7 @@ Hit **Send**.
 
 You can now see the new notification that the submission is awaiting copyedits, the Copyeditor is now included in the Participants list, and the request is visible in the Copyediting Discussions.
 
-![](./assets/learning-ojs-3-ed-copyediting-add-dash.png)
+![The "Awaiting Copyediting" notification and updated participants list.](./assets/learning-ojs-3-ed-copyediting-add-dash.png)
 
 You can now wait for the Copyeditor to do their work.
 
@@ -625,11 +617,11 @@ The Copyeditor will receive an email message from the Section Editor requesting 
 
 To get started, they must login and find the submission from their dashboard.
 
-![](./assets/learning-ojs-3-ce-dash.png)
+![The Copyeditor's submission queue.](./assets/learning-ojs-3-ce-dash.png)
 
 Then, they can click the Copyediting link next to the submission name. This will take them directly to the Copyediting stage for this submission.
 
-![](./assets/learning-ojs-3-ce-submission.png)
+![The Copyediting stage as seen by an assigned Copyeditor.](./assets/learning-ojs-3-ce-submission.png)
 
 From here, they can see the Draft Files. These are the files that require copyediting. Clicking on the linked title will download the file to their desktop.
 
@@ -651,35 +643,35 @@ Once they have finished copyediting, they will run the changes past the Author b
 
 From the Add Discussion window, they must choose the Author and add a subject line and message.
 
-![](./assets/learning-ojs-3-ce-add-discussion.png)
+![The Add Discussion window.](./assets/learning-ojs-3-ce-add-discussion.png)
 
 Further down that same window, they must upload a copy of the copyedited file.
 
-![](./assets/learning-ojs-3-ce-add-discussion2.png)
+![The file upload area of the Add Discussion window.](./assets/learning-ojs-3-ce-add-discussion2.png)
 
 To do so, use the *Upload File* link. This will open a new window where you must choose the *Article Component* (e.g., article text) and upload the file.
 
-![](./assets/learning-ojs-3-ce-upload1.png)
+![The File Upload screen.](./assets/learning-ojs-3-ce-upload1.png)
 
 Hit **Continue** to proceed.
 
 This will open the next step, where you can edit the filename if needed.
 
-![](./assets/learning-ojs-3-ce-upload2.png)
+![The Edit option next to the file name.](./assets/learning-ojs-3-ce-upload2.png)
 
 Next, you can upload more files if necessary, or hit **Complete**.
 
-![](./assets/learning-ojs-3-ce-upload3.png)
+![The Confirmation step of the file upload.](./assets/learning-ojs-3-ce-upload3.png)
 
 Back on the Add window, you can now see the attached file.
 
-![](./assets/learning-ojs-3-ce-upload4.png)
+![The newly upload file attached to the discussion.](./assets/learning-ojs-3-ce-upload4.png)
 
 Hit **OK** to send the message to the author.
 
 It is now visible in the Copyediting Discussions.
 
-![](./assets/learning-ojs-3-ce-discussion.png)
+![The discussion added to the Copyediting Discussions section.](./assets/learning-ojs-3-ce-discussion.png)
 
 You can now wait for the author's response.
 
@@ -687,21 +679,21 @@ You can now wait for the author's response.
 
 Once you hear back from the author, you can review their feedback by checking the discussion reply.
 
-![](./assets/learning-ojs-3-se-author-copyedits.png)
+![The previous Copyediting Discussion now containing a "1" in the reply column.](./assets/learning-ojs-3-se-author-copyedits.png)
 
 From here, you can see no further changes are required.
 
-![](./assets/learning-ojs-3-se-author-copyedits-reply.png)
+![A sample reply from an author approving the copyediting.](./assets/learning-ojs-3-se-author-copyedits-reply.png)
 
 ### The Final Copyedited File
 
 Now you can go ahead and upload the final copyedited version to the Copyedited panel, near the bottom of the screen.
 
-![](./assets/learning-ojs-3-ce-copyedited.png)
+![The Upload/Select Files option can be found near the Copyedited section of the panel.](./assets/learning-ojs-3-ce-copyedited.png)
 
 Use the Upload/Select Files link to upload the final copyedited version.
 
-![](./assets/learning-ojs-3-ce-copyedited-upload-select.png)
+![The Upload/Select Files window.](./assets/learning-ojs-3-ce-copyedited-upload-select.png)
 
 It is important to note here that you have a few choices.
 
@@ -715,7 +707,7 @@ Hit **OK**.
 
 The file is now visible in the *Copyedited* panel (near the bottom of the screen), indicating to the editor that this is the final version, which is ready for the Production stage.
 
-![](./assets/learning-ojs-3-ce-copyedited2.png)
+![The selected file seen in the Copyedited panel.](./assets/learning-ojs-3-ce-copyedited2.png)
 
 ### Inform the Section Editor
 
@@ -723,17 +715,17 @@ The final step is for you to inform the Section Editor that the copyediting is c
 
 To do so, start a new Copyediting Discussion by using the *Add Discussion* link.
 
-![](./assets/learning-ojs-3-ce-copyedited-final.png)
+![The list of Copyediting Discussions ](./assets/learning-ojs-3-ce-copyedited-final.png)
 
 In the discussion window, add the Section Editor, a subject line, and a message.
 
-![](./assets/learning-ojs-3-ce-copyedited-discussion.png)
+![A sample message from the Copy Editor to the Section Editor](./assets/learning-ojs-3-ce-copyedited-discussion.png)
 
 Hit **OK** to send the message.
 
 Returning to the Copyediting stage, you can see the message is posted.
 
-![](./assets/learning-ojs-3-ce-copyedited-done.png)
+![The message added to the list of copyediting discussions.](./assets/learning-ojs-3-ce-copyedited-done.png)
 
 Your work as the Copyeditor is now complete!
 
@@ -741,11 +733,11 @@ Your work as the Copyeditor is now complete!
 
 The Section Editor will receive an email that the copyediting is complete, and see a notification in the discussions.
 
-![](./assets/learning-ojs-3-se-copyedited-dash.png)
+![The Copyediting Stage in the Section Editor's dashboard](./assets/learning-ojs-3-se-copyedited-dash.png)
 
 You can download and review the final copyedited version from the Copyedited panel.
 
-![](./assets/learning-ojs-3-se-copyedited-files.png)
+![The final copyedited version uploaded to the Copyedited panel. ](./assets/learning-ojs-3-se-copyedited-files.png)
 
 At this point you could communicate further with the Copyeditor, or, if you are satisfied, move the submission to the Production stage.
 
@@ -753,7 +745,7 @@ To do so, select the blue **Send to Production** button.
 
 This will generate an official notice to the Authors that the submission is moving to the next stage.
 
-![](./assets/learning-ojs-3-se-send-to-production.png)
+![The Send to Production window with notification to the author.](./assets/learning-ojs-3-se-send-to-production.png)
 
 Notice that the appropriate file, from the Copyedited panel, is included and will be automatically transferred to Production.
 
@@ -761,4 +753,4 @@ Hit **Record Editorial Decision** to proceed.
 
 The Copyediting stage is now complete and the submission status will be updated. The next chapter covers the Production and Publication stage.
 
-![](./assets/learning-ojs3.2_edflow_decisionstatus_copyedit.png)
+![The "Sent to production" status.](./assets/learning-ojs3.2_edflow_decisionstatus_copyedit.png)


### PR DESCRIPTION
Added so much alt text. Putting some notes here about needed updates for later (these notes are also in the alt text tasks spreadsheet)
NOTES: learning-ojs-3-ed-rev-add-4.png, learning-ojs-3.2-cancel-reviewer.png need to be updated (contains references to "double-blind"). learning-ojs-3-se-copyedited-dash.png should be changed to better fit the text.