### PR TITLE
fix admin-guide links

### DIFF
--- a/_includes/cards/dev/admin-guide.md
+++ b/_includes/cards/dev/admin-guide.md
@@ -1,16 +1,16 @@
 
-### [Administrator's Guide](admin-guide/)
+### [Administrator's Guide](/admin-guide/)
 
 A guide for system administrators of PKP applications. [View Now](/admin-guide/)
 
 ---
 
-- [Installing and Upgrading](admin-guide/en/managing-the-environment)
-- [Data Import and Export](admin-guide/en/data-import-and-export)
-- [Statistics](admin-guide/en/statistics)
-- [Email](admin-guide/en/email)
-- [Troubleshooting](admin-guide/en/troubleshooting)
-- ... and [more](admin-guide/en/).
+- [Installing and Upgrading](/admin-guide/en/managing-the-environment)
+- [Data Import and Export](/admin-guide/en/data-import-and-export)
+- [Statistics](/admin-guide/en/statistics)
+- [Email](/admin-guide/en/email)
+- [Troubleshooting](/admin-guide/en/troubleshooting)
+- ... and [more](/admin-guide/en/).
 
 ---
 


### PR DESCRIPTION
the admin-guide links were misdirected because they're missing a leading slash.