### PR TITLE
Link to upgrade and metadata guides

### DIFF
--- a/accessible-content/en/principles.md
+++ b/accessible-content/en/principles.md
@@ -443,7 +443,7 @@ To [create accessible tables in Microsoft Word](https://kb.iu.edu/d/aqjl):
 
 ## Document metadata
 
-Adding metadata to your document increases its searchability. It also allows software applications and adaptive technologies to give the users the key information about the document, so they can easily find the desired document and determine if it is what they need.
+Adding metadata to your document increases its searchability. It also allows software applications and adaptive technologies to give the users the key information about the document, so they can easily find the desired document and determine if it is what they need. To learn more, see [the Better Practices in Journal Metadata guide](/metadata-practices/en/).
 
 ### Filename
 

--- a/google-scholar/en/index.md
+++ b/google-scholar/en/index.md
@@ -71,7 +71,7 @@ If you notice that Google Scholar has not indexed or ceased indexing your journa
 
 - Authors listed in a different order in metatags than the author order in the gallery
 
-Follow the steps below to check for consistency in your journal's metadata. If the metadata seems to be correct but your journal's articles do not appear in Google Scholar search results, it may take some time before the changes show up in the Google Scholar site, as once Google Scholar has indexed an article, any changes will not be reflected until Google Scholar makes changes to its' index (which occurs twice yearly). Should the changes still not appear, contact your site administrator for further support for further troubleshooting (see the 'Troubleshooting Google Scholar indexing problems" for site administrators' section, below).
+Follow the steps below to check for consistency in your journal's metadata. If the metadata seems to be correct but your journal's articles do not appear in Google Scholar search results, it may take some time before the changes show up in the Google Scholar site, as once Google Scholar has indexed an article, any changes will not be reflected until Google Scholar makes changes to its' index (which occurs twice yearly). Should the changes still not appear, contact your site administrator for further support for further troubleshooting (see the ['Troubleshooting for Site Administrators' section](#troubleshooting-for-site-administrators)). To learn more about metadata practices, see [the Better Practices in Journal Metadata guide](/metadata-practices/en/).
 
 ### Check for consistency in the publication date
 
@@ -152,7 +152,7 @@ To troubleshoot and fix these errors, you will want to compare the names in the 
 
 If you notice that Google Scholar has not indexed or ceased indexing your journal, there are a few potential causes. Google Scholar will stop indexing a journal if:
 
-- There are high numbers of metadata errors (see the Google Scholar indexing for Journal Managers section of this guide for details)
+- There are high numbers of metadata errors (see the [Troubleshooting for Journal Managers and Editors section](#troubleshooting-for-journal-managers-and-editors) for details)
 - The metatags are missing entirely (a known bug for upgrades to some versions of OJS)
 - The HTTPS certificate is invalid or expired
 - There are frequent site downtimes

--- a/journal-policies-workflows/en/alternative-uses.md
+++ b/journal-policies-workflows/en/alternative-uses.md
@@ -11,7 +11,7 @@ OJS can be used for the entire journal management process, from submissions thro
 Your journal may choose to use OJS to manage the submission workflow and coordinate communications between editors and authors as work moves through submission, peer review, copyediting, and other aspects of the editorial and publishing workflow. If you are only using OJS to manage your submission workflow and not publish your content, you can do the following:
 
 1. In the **Settings** > **Distribution** > **Access** setting select “OJS will not be used to publish the journal’s contents online.”
-2. In the **Settings** > **Distribution** > **Access** disable OAI (Open Archives Initiative) to prevent indexing services from harvesting the journal metadata. 
+2. In the **Settings** > **Distribution** > **Access** disable OAI (Open Archives Initiative) to prevent indexing services from harvesting the journal metadata.
 
 See [Learning OJS > Distribution Settings > Access](https://docs.pkp.sfu.ca/learning-ojs/en/settings-distribution#access) for more information and instructions for changing these settings.
 

--- a/learning-ojs/en/authoring.md
+++ b/learning-ojs/en/authoring.md
@@ -68,7 +68,7 @@ On **Step 3**, you will be asked to add more information about the submission, i
 
 ![List of contributors](./assets/learning-ojs3.1-au-dashboard-new-3-contrib.png)
 
-You can add more contributors \(e.g., co-authors\), by clicking the **Add Contributors** link. This will open a new window with fields to enter their information.
+You can add more contributors (e.g., co-authors), by clicking the **Add Contributors** link. This will open a new window with fields to enter their information.
 
 ![Add contributors](./assets/learning-ojs-3-author-submission-step3-2.png)
 

--- a/learning-ojs/en/installing-upgrading.md
+++ b/learning-ojs/en/installing-upgrading.md
@@ -8,11 +8,12 @@ description: A basic resource for finding more information on installing or upgr
 
 OJS 3 is a PHP web application with standardized install and upgrade processes. These processes are kept as simple as possible, though some general systems administration experience is recommended.
 
-Up to date OJS system requirements, as well as installation, upgrade, and configuration instructions can be found in the following locations:
+Up-to-date OJS system requirements, as well as installation, upgrade, and configuration instructions can be found in the following locations:
 
 * in the package you downloaded from the [OJS download page](https://pkp.sfu.ca/ojs/ojs_download/) (look in the `docs/` directory);
+* in the technical [How to Upgrade Guide](/dev/upgrade-guide/);
 * directly in the online [README](https://pkp.sfu.ca/ojs/README) or [UPGRADE](https://pkp.sfu.ca/ojs/UPGRADE) documents;
-* in the PKP [Administrator's Guide](/admin-guide).
+* in the PKP [Administrator's Guide](/admin-guide/).
 
 For those who want to install from source via Git, instructions can be found directly on [GitHub](https://github.com/pkp/ojs).
 

--- a/learning-ojs/en/journal-setup.md
+++ b/learning-ojs/en/journal-setup.md
@@ -31,7 +31,7 @@ Use the tabs to navigate to the different sections of Journal Settings: Masthead
 
 Note that the publisher name entered here is used for metadata but will not be displayed on your site. To show the publisher name on your site you can enter it under Journal Settings > Contact > Mailing Address. You can also add it under About the Journal below.
 
-**ISSN** \(International Standard Serial Number\) is an eight-digit number which identifies journals. It is managed by a world wide network of National Centres coordinated by an International Centre based in Paris, backed by Unesco and the French Government. A number can be obtained from the [ISSN web site](http://www.issn.org/). This can be done at any point in operating the journal.
+**ISSN** (International Standard Serial Number) is an eight-digit number which identifies journals. It is managed by a world wide network of National Centres coordinated by an International Centre based in Paris, backed by Unesco and the French Government. A number can be obtained from the [ISSN web site](http://www.issn.org/). This can be done at any point in operating the journal.
 
 OJS journals will typically have an online ISSN, but some may also publish a print version, which requires a different print ISSN.
 

--- a/learning-ojs/en/production-publication.md
+++ b/learning-ojs/en/production-publication.md
@@ -400,7 +400,7 @@ The next step in publishing the submission is to check and finalize the metadata
 
 ## Finalize Metadata
 
-Before publishing the submission, you should check that the metadata for the article is complete and accurate in OJS and matches the metadata on the PDF. This is important for ensuring that the content is indexed by Google Scholar, discoverable by other services, and accessible to readers.
+Before publishing the submission, you should check that the metadata for the article is complete and accurate in OJS and matches the metadata on the PDF. This is important for ensuring that the content is indexed by Google Scholar, discoverable by other services, and accessible to readers. To learn more, see [the Better Practices in Journal Metadata guide](/metadata-practices/en/).
 
 You can check the metadata for the submission by going to **Submissions**, opening the submission, going to the **Publication** tab, and checking the **Title**, **Contributors**, and **Metadata** tabs.
 

--- a/learning-omp/en/install-upgrade.md
+++ b/learning-omp/en/install-upgrade.md
@@ -10,8 +10,9 @@ OMP 3 is a PHP web application with standardized install and upgrade processes. 
 Up-to-date OMP system requirements, as well as installation, upgrade, and configuration instructions, can be found in the following locations:
 
 * In the package you downloaded from the [OMP download page](https://pkp.sfu.ca/omp/omp_download/). (Look in the docs/ directory);
-* Directly in the online [README file](https://pkp.sfu.ca/omp/README) or [UPGRADE](https://pkp.sfu.ca/omp/UPGRADE) documents; and
-* In the [PKP Administrator’s Guide](/admin-guide/)
+* Directly in the online [README file](https://pkp.sfu.ca/omp/README) or [UPGRADE](https://pkp.sfu.ca/omp/UPGRADE) documents; 
+* In the [PKP Administrator’s Guide](/admin-guide/); and
+* In the technical [How to Upgrade Guide](/dev/upgrade-guide/).
 
 For those who want to install from source via Git, instructions can be found directly on [GitHub](https://github.com/pkp/omp).
 

--- a/learning-ops/en/setup.md
+++ b/learning-ops/en/setup.md
@@ -29,7 +29,7 @@ The **Description** provides an overview of the preprint server and appears on t
 
 ![Sample server team information entered into OPS.](./assets/learning-ops-server-settings-server-team.png)
 
-Note that the terminology may be different for OPS, with some slight modifications. For example, a Moderator would be the equivalent of a Journal Manager and a Preprint server library is equivalent to the Publisher Library. 
+Note that the terminology may be different for OPS, with some slight modifications. For example, a Moderator would be the equivalent of a Journal Manager and a Preprint server library is equivalent to the Publisher Library.
 
 ### Contact
 
@@ -87,7 +87,7 @@ The Plugins tab under Website Settings lists pre-installed plugins under Install
 
 **AddThis**: This plugin allows adding social media sharing buttons to the preprint landing page. For a better usage, it is recommended to register an account at AddThis.
 
-**Browse Plugin**: This plugin adds the ability to browse by Categories and sub-categories through the Servers homepage. To configure this plugin, please refer to [Plugin Section of OPS]().
+**Browse Plugin**: This plugin adds the ability to browse by Categories and sub-categories through the Servers homepage.
 
 ![An instance of OPS with the Browse plugin enabled.](./assets/learning-ops-website-settings-browse-plugin.png)
 

--- a/student-toolkit/en/ojs.md
+++ b/student-toolkit/en/ojs.md
@@ -10,8 +10,8 @@ Check out this page for some [examples of journals hosted with OJS](https://pkp.
 
 There are a few tools for the OJS system:
 
--   PKP School online courses - [Setting up a Journal in OJS](https://pkpschool.sfu.ca/courses/setting-up-a-journal-in-ojs-3/) and [Editorial Workflow in OJS](https://pkpschool.sfu.ca/courses/editorial-workflow-in-ojs-3/)
--   PKP Docs: [Learning OJS 3](https://docs.pkp.sfu.ca/learning-ojs/en/)
--   The PKP [community forum](https://forum.pkp.sfu.ca/)
+- PKP School online courses - [Setting up a Journal in OJS](https://pkpschool.sfu.ca/courses/setting-up-a-journal-in-ojs-3/) and [Editorial Workflow in OJS](https://pkpschool.sfu.ca/courses/editorial-workflow-in-ojs-3/)
+- PKP Docs: [Learning OJS 3](https://docs.pkp.sfu.ca/learning-ojs/en/)
+- The PKP [community forum](https://forum.pkp.sfu.ca/)
 
 OJS comes with plugins that support theme customization, social media sharing, usage statistics, and more. Additionally, OJS has collaborated with CrossRef, an organization dedicated to making scholarly communication better by using metadata to “find, cite, link, and assess” content (crossref.org). There is a plugin and [documentation on using CrossRef with OJS](https://docs.pkp.sfu.ca/crossref-ojs-manual/en/).


### PR DESCRIPTION
Adds links to the tech upgrade guide and metadata practices guide to other docs. Also removed a broken link in Learning OPS.