### PR TITLE
Reduce margins for nested lists

### DIFF
--- a/_sass/components/book.scss
+++ b/_sass/components/book.scss
@@ -79,6 +79,12 @@
 		margin-bottom: 2em;
 	}
 
+	ol ul,
+	ul ul {
+		margin-top: 1em;
+		margin-bottom: 1em;
+	}
+
 	li {
 		line-height: 1.8em;
 	}

--- a/_sass/components/book.scss
+++ b/_sass/components/book.scss
@@ -80,9 +80,11 @@
 	}
 
 	ol ul,
-	ul ul {
-		margin-top: 1em;
-		margin-bottom: 1em;
+	ul ul,
+	ol ol,
+	ul ol {
+		margin-top: 0.5rem;
+		margin-bottom: 0.5rem;
 	}
 
 	li {
@@ -90,7 +92,7 @@
 	}
 
 	li + li {
-		margin-top: 1em;
+		margin-top: 0.5rem;
 	}
 
 	blockquote {

--- a/dev/upgrade-guide/en/index.md
+++ b/dev/upgrade-guide/en/index.md
@@ -314,7 +314,6 @@ It's important to test the site after an upgrade. Any core functions for your jo
 
 The following is a short checklist that covers common use cases.
 
-```
 1. Reader interface
     - The homepage loads
     - The theme loads correctly
@@ -350,7 +349,6 @@ The following is a short checklist that covers common use cases.
         - Change new user's profile data and password
         - Remove the new user by merging it to your admin account
 6. Additional testing of common tasks
-```
 
 ### 11. Restore Custom Plugins
 


### PR DESCRIPTION
During the upgrade guide development, it was noted that there is a lot of extra spacing in nested lists (#856). This change should reduce that, and converts the upgrade guide list back into a standard list.

Examples from https://docs.pkp.sfu.ca/accessible-content/en/principles#where-to-add-alt-text 

Before change:

![Screen Shot 2022-01-21 at 1 00 25 PM](https://user-images.githubusercontent.com/6903515/150577411-13b52abb-ff22-4ddc-bfcd-08dc1c0043e6.png)

After change:

![Screen Shot 2022-01-21 at 1 00 36 PM](https://user-images.githubusercontent.com/6903515/150577428-cc4dd722-a7e4-48ac-8a4b-c63d9f1ae1e8.png)
