### PR TITLE
Increase heading sizes in guides

### DIFF
--- a/_sass/components/book.scss
+++ b/_sass/components/book.scss
@@ -62,8 +62,28 @@
 	h1 {
 		margin-top: 0;
 		margin-bottom: 1.5rem;
-		font-size: 2.2rem;
+		font-size: 2.25rem;
 		line-height: 1.2em;
+	}
+
+	h2 {
+		font-size: 2rem;
+	}
+
+	h3 {
+		font-size: 1.75rem;
+	}
+
+	h4 {
+		font-size: 1.5rem;
+	}
+
+	h5 {
+		font-size: 1.25rem;
+	}
+
+	h6 {
+		font-size: 1rem;
 	}
 
 	p {


### PR DESCRIPTION
Declare and increase the sizes of the headings within the content of the guides. Resolves #857.

### Current heading sizes:

<img width="720" alt="Current heading sizes" src="https://user-images.githubusercontent.com/6903515/152577218-9834567c-05fb-4945-9be6-1785b8029cbb.png">

------

### New heading sizes:

<img width="730" alt="New heading sizes" src="https://user-images.githubusercontent.com/6903515/152577230-e1c8e8fe-5c94-4376-a111-ff7a76739c98.png">

