### PR TITLE
Remove chapter number references

### DIFF
--- a/_includes/cards/ojs2/upgrading-guide.md
+++ b/_includes/cards/ojs2/upgrading-guide.md
@@ -1,5 +1,5 @@
 
-### [ Upgrading from OJS 2 to OJS 3 ](/upgrading-ojs-2-to-3/)
+### [Upgrading from OJS 2 to OJS 3](/upgrading-ojs-2-to-3/)
 
 In this guide, we describe some of the changes between OJS 2 and OJS 3 and suggest steps for planning and completing your migration. [View Now](/upgrading-ojs-2-to-3/)
 

--- a/_includes/cards/ojs3/upgrading-guide.md
+++ b/_includes/cards/ojs3/upgrading-guide.md
@@ -1,5 +1,5 @@
 
-### [ Upgrading from OJS 2 to OJS 3 ](/upgrading-ojs-2-to-3/)
+### [Upgrading from OJS 2 to OJS 3](/upgrading-ojs-2-to-3/)
 
 In this guide, we describe some of the changes between OJS 2 and OJS 3 and suggest steps for planning and completing your migration. [View Now](/upgrading-ojs-2-to-3/)
 

--- a/accessible-content/en/galleys.md
+++ b/accessible-content/en/galleys.md
@@ -93,7 +93,7 @@ Remediating a document in PDF requires Adobe Acrobat Pro. For more details see t
 
 HTML is another popular galley format used by publishers. It offers more flexibility than PDF for adjusting to different screen sizes and accommodating multimedia. It has the potential to be more accessible than PDF as long as the document follows the [general principles of creating accessible content](./principles.md#headings-structure), such as structured headings, alt text, etc.
 
-For instructions on how to create and style HTML galleys, add multimedia content, and upload HTML galleys to OJS, see the [Learning OJS 3 - Chapter 15: Production and Publication - HTML Files](/learning-ojs/en/production-publication#html-files).
+For instructions on how to create and style HTML galleys, add multimedia content, and upload HTML galleys to OJS, see [Learning OJS 3: Production and Publication - HTML Files](/learning-ojs/en/production-publication#html-files).
 
 ### XML
 

--- a/doaj/en/index.md
+++ b/doaj/en/index.md
@@ -41,7 +41,7 @@ The DOAJ requires journals to adopt a form of Libre Open Access—a type of open
 
 **The journal website must display its open access statement. Where can we find this information?** \[**D**\]
 
-* Enter this information in Journal Settings > Masthead > About the Journal. See [Chapter 5: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#masthead).
+* Enter this information in Journal Settings > Masthead > About the Journal. See [Learning OJS: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#masthead).
 * You may want to create a section in the text box for the Open Access statement.
 * An example of an acceptable OA statement is: _"This is an open access journal which means that all content is freely available without charge to the user or his/her institution. Users are allowed to read, download, copy, distribute, print, search, or link to the full texts of the articles, or use them for any other lawful purpose, without asking prior permission from the publisher or the author. "_
 * If your journal has a Creative Commons license, this Open Access statement is true of your journal. For instructions on where to add your CC license, see #14.
@@ -50,7 +50,7 @@ The DOAJ requires journals to adopt a form of Libre Open Access—a type of open
 
 **Journal Title** \[**D**\]
 
-* Add this at Journal Settings > Masthead. See [Chapter 5: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#masthead).
+* Add this at Journal Settings > Masthead. See [Learning OJS: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#masthead).
 
 **Alternative title (including the translation of the title)** \[Optional\]
 
@@ -63,16 +63,16 @@ The DOAJ requires journals to adopt a form of Libre Open Access—a type of open
 **Journal ISSN (print)** (only add if you have one) \[**D**\]
 
 * This information needs to be added in two places:
-  * Journal Settings > Masthead > ISSN. See [Chapter 5: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#masthead).
-  * Add to your journal footer for it to appear on your site. See [Chapter 5: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#appearance).
+  * Journal Settings > Masthead > ISSN. See [Learning OJS: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#masthead).
+  * Add to your journal footer for it to appear on your site. See [Learning OJS: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#appearance).
 
 * The ISSN will appear on the footer on every page of your site.
 
 **ISSN (online)** \[**D**\]
 
 * This information needs to be added in two places:
-  * Journal Settings > Masthead > ISSN. See [Chapter 5: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#masthead).
-  * Add to your journal footer for it to appear on your site. See [Chapter 5: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#appearance).
+  * Journal Settings > Masthead > ISSN. See [Learning OJS: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#masthead).
+  * Add to your journal footer for it to appear on your site. See [Learning OJS: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#appearance).
 
 * The ISSN will appear on the footer on every page of your site.
 
@@ -89,12 +89,12 @@ The DOAJ requires journals to adopt a form of Libre Open Access—a type of open
 **Publisher's name** \[**D**\]
 
 * Enter this information in 2 places:
-  * Journal Settings > Masthead > Publisher (it will be supplied to 3rd party metadata services, but will not appear publicly on your site). See [Chapter 5: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#appearance).
-  * Journal Settings > Contact > Mailing Address (the Publisher name will appear on the Contact page of your site, which is required by DOAJ). See [Chapter 5: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#appearance).
+  * Journal Settings > Masthead > Publisher (it will be supplied to 3rd party metadata services, but will not appear publicly on your site). See [Learning OJS: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#appearance).
+  * Journal Settings > Contact > Mailing Address (the Publisher name will appear on the Contact page of your site, which is required by DOAJ). See [Learning OJS: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#appearance).
 
 **Publisher's country** \[**D**\]
 
-* Enter this information at Journal Settings > Contact > Mailing Address. A full mailing address is preferred. See [Chapter 5: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#contact).
+* Enter this information at Journal Settings > Contact > Mailing Address. A full mailing address is preferred. See [Learning OJS: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#contact).
 * The country will appear on the Contact page of your site.
 
 #### Society or institution, if applicable \[Optional\]
@@ -103,7 +103,7 @@ The DOAJ requires journals to adopt a form of Libre Open Access—a type of open
 
 **Society or institution’s country**
 
-* Information about a society or institution that sponsors the journal can be entered in Journal Settings > Masthead > About the Journal. See [Chapter 5: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#masthead).
+* Information about a society or institution that sponsors the journal can be entered in Journal Settings > Masthead > About the Journal. See [Learning OJS: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#masthead).
 * You may want to create a special section on the About the Journal page about a sponsoring organization. Both fields can be left blank.
 
 ### Copyright & licensing
@@ -124,9 +124,9 @@ The DOAJ requires journals to adopt a form of Libre Open Access—a type of open
   * Publisher's own license
 
 * For more information see [the Creative Commons page on licenses](https://creativecommons.org/licenses/).
-* Enter this information in OJS at Distribution Settings > Permissions > License. See [Chapter 8: Distribution Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-distribution#permissions).
+* Enter this information in OJS at Distribution Settings > Permissions > License. See [Learning OJS: Distribution Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-distribution#permissions).
 * The license you select here will not be displayed on your site automatically. You can add it to your [About the Journal page](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#masthead), to [the footer of your site](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#appearance), or another place.
-* You can also enter license information on a per article basis when you schedule an article for publication and it will be displayed on the article page. See [Chapter 14: Editorial Workflow](https://docs.pkp.sfu.ca/learning-ojs/en/editorial-workflow#scheduling-for-publication).
+* You can also enter license information on a per article basis when you schedule an article for publication and it will be displayed on the article page. See [Learning OJS: Editorial Workflow](https://docs.pkp.sfu.ca/learning-ojs/en/editorial-workflow#scheduling-for-publication).
 * If you allow more than one type of license, please select all licenses used by the journal.
 
 **Where can we find this information?** \[**D**\]\[**S**\]
@@ -143,7 +143,7 @@ The DOAJ requires journals to adopt a form of Libre Open Access—a type of open
 * Select "Yes" or "No".
 * Answer Yes only if you include the CC license in the full text PDFs. If "Yes", please include the URL of a recent example article in the box that appears once "Yes" is selected.
 * Select the Creative Commons license you will use in:
-Settings > Distribution > Permissions. See [Chapter 8: Distribution Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-distribution#permissions).
+Settings > Distribution > Permissions. See [Learning OJS: Distribution Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-distribution#permissions).
 * If you wish to embed license information for articles, you must add it to all PDF galley files you upload to submissions during the Production stage.
 
 #### Copyright
@@ -157,8 +157,8 @@ Settings > Distribution > Permissions
 **Where can we find this information?**  \[**D**\]
 
 * Enter the URL of the journal's copyright statement.
-* You can enter your copyright statement in the Copyright Notice box. See [Chapter 8: Distribution Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-distribution#permissions) and select the copyright holder (Author, Journal, or Other).
-* The Copyright Notice will be displayed with each published article. To provide a link to your statement, you can add it on the About the Journal page, in Journal Settings > Masthead > About the Journal. See [Chapter 5: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#masthead).
+* You can enter your copyright statement in the Copyright Notice box. See [Learning OJS: Distribution Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-distribution#permissions) and select the copyright holder (Author, Journal, or Other).
+* The Copyright Notice will be displayed with each published article. To provide a link to your statement, you can add it on the About the Journal page, in Journal Settings > Masthead > About the Journal. See [Learning OJS: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#masthead).
 
 ### Editorial
 
@@ -176,7 +176,7 @@ Settings > Distribution > Permissions
   * Other
 
 * The type of review must be clearly labeled and described. "Editorial Review" is only valid for journals in Arts or Humanities. Non-humanities journals may not use this option with the DOAJ.
-* Enter this information in Journal Settings > Masthead > About the Journal. See [Chapter 5: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#masthead).
+* Enter this information in Journal Settings > Masthead > About the Journal. See [Learning OJS: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#masthead).
 * You may want to create a special section on the About the Journal page to describe the review process.
 
 **Where can we find this information?**  \[**D**\]
@@ -195,17 +195,17 @@ Settings > Distribution > Permissions
 
 **Link to the journal’s Aims & Scope** \[**D**\]
 
-* Enter this information in Journal Settings > Workflow > Submissions > Author Guidelines. See [Chapter 5: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#masthead).
+* Enter this information in Journal Settings > Workflow > Submissions > Author Guidelines. See [Learning OJS: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#masthead).
 * You may want to create a section in the text box for the journal’s Aims & Scope. It will appear publicly on the About > About the Journal page.
 
 **Link to the journal’s Editorial board** \[**D**\]
 
-* Enter this information under Journal Settings > Masthead > Editorial Team. See [Chapter 5: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#masthead).
+* Enter this information under Journal Settings > Masthead > Editorial Team. See [Learning OJS: Journal Settings](https://docs.pkp.sfu.ca/learning-ojs/en/journal-setup#masthead).
 * This will appear publicly under About > Editorial Team.
 
 **Link to the journal’s Instructions for authors** \[**D**\]
 
-* Enter this information in Journal Settings > Workflow > Submission > Author Guidelines. See [Chapter 7: Workflow Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-workflow#submission).
+* Enter this information in Journal Settings > Workflow > Submission > Author Guidelines. See [Learning OJS: Workflow Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-workflow#submission).
 * Information entered in Author Guidelines and Submission Preparation Checklist will appear publicly on the About > Submissions page.
 
 **Average number of weeks between article submission & publication**
@@ -221,8 +221,8 @@ Settings > Distribution > Permissions
 * Select "Yes" or "No".
 * If "Yes", please select the currency and amount for the highest fee charged by the journal in the fields that appear when "Yes" is selected.
 * Enter this information in two places:
-  * Settings > Website> Information > For Authors. See [Chapter 6: Website Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#information).
-  * Settings > Workflow > Submission > Submission Preparation Checklist. See [Chapter 7: Workflow Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-workflow#submission).
+  * Settings > Website> Information > For Authors. See [Learning OJS: Website Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#information).
+  * Settings > Workflow > Submission > Submission Preparation Checklist. See [Learning OJS: Workflow Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-workflow#submission).
 
 **Where can we find this information?** \[**D**\]
 
@@ -234,8 +234,8 @@ Settings > Distribution > Permissions
 
 * Select "Yes" or "No". Answer "No" if you have also answered No to Publication Fees.
 * Enter this information in two places:
-  * Settings > Website> Information > For Authors. See See [Chapter 6: Website Setting](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#information).
-  * Settings > Workflow > Submission > Submission Preparation Checklist. See [Chapter 7: Workflow Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-workflow#submission).
+  * Settings > Website> Information > For Authors. See See [Learning OJS: Website Setting](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#information).
+  * Settings > Workflow > Submission > Submission Preparation Checklist. See [Learning OJS: Workflow Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-workflow#submission).
 * If "Yes", please enter the URL where the waiver policy can be found in the box that appears when "Yes" is selected. The waiver policy will appear on the About/Submissions page on your site and on the Information/Authors page on your site.
 
 #### Other Fees
@@ -266,7 +266,7 @@ DOAJ recommends adoption of the following best practices, but these are not requ
   * The journal content isn’t archived with a long-term preservation service
 
 * Institutional archives and publishers' own online archives are not valid.
-* If you are a member of LOCKSS or CLOCKSS, enable this here in Settings > Website > Archiving. See [Chapter 6: Website Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#archiving).
+* If you are a member of LOCKSS or CLOCKSS, enable this here in Settings > Website > Archiving. See [Learning OJS: Website Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#archiving).
 * The PKP PN is available as part of OJS. Please read the [PKP Preservation Network Guide](https://docs.pkp.sfu.ca/pkp-pn/) for more information.
 * If any service(s) are selected, you will be prompted to enter the URL with information on your preservation policy. If you are archiving your content in a LOCKSS network, this will not automatically be displayed on your OJS site. You can add your archiving policy to the About page or another page and link to it here.
 
@@ -326,7 +326,7 @@ This demonstrates that the journal ensures the long-term availability and preser
 If you are a member of LOCKSS or CLOCKSS, enable this here:
 Settings > Website > Archiving
 
-See [Chapter 6: Website Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#archiving) for more details.
+See [Learning OJS: Website Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#archiving) for more details.
 
 ### 2. Persistent article identifiers
 
@@ -361,7 +361,7 @@ To ensure readers (users) know and understand what they are permitted to do with
 OJS offers the Creative Commons license options that are acceptable for the DOAJ seal: CC BY, CC BY-SA, CC BY-NC, or CC BY-NC-SA. This license will be embedded in the metadata of published items and displayed on the item’s webpage.
 Select the Creative Commons license you will use in Settings > Distribution > Permissions
 
-See [Chapter 8: Distribution Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-distribution#permissions) for more details.
+See [Learning OJS: Distribution Settings](https://docs.pkp.sfu.ca/learning-ojs/en/settings-distribution#permissions) for more details.
 
 ### 6. Copyright and publishing rights
 

--- a/instructor-guide/en/setup-workflow.md
+++ b/instructor-guide/en/setup-workflow.md
@@ -17,12 +17,12 @@ The basic steps for starting a new journal are found in [Getting Started](https:
 ### Reviewer:
 
 - The [Becoming a Reviewer](https://pkpschool.sfu.ca/courses/becoming-a-reviewer/) course from the [PKP School](https://pkpschool.sfu.ca/) is designed to help you understand the critical role played by reviewers in advancing science and scholarship, discover the professional benefits you will receive by volunteering your time as a reviewer, learn how to write a useful review that will help your editor and the author, effectively work with OJS, a popular open source, online journal management and peer review system, and become a better reviewer over time.
-- [Learning OJS 3 Chapter 15: Reviewing](https://docs.pkp.sfu.ca/learning-ojs/en/reviewing) provides an overview of how to complete review tasks in OJS 3.
+- [Learning OJS 3: Reviewing](https://docs.pkp.sfu.ca/learning-ojs/en/reviewing) provides an overview of how to complete review tasks in OJS 3.
 
 ### Author:
 
 - The [Writing for Publication](https://pkpschool.sfu.ca/courses/writing-for-publication/) course provides authors with the thinking skills and strategies necessary to create effective and publishable articles from their research.
-- [Learning OJS 3 Chapter 13: Authoring](https://docs.pkp.sfu.ca/learning-ojs/en/authoring) provides an overview of how to complete authoring tasks in OJS 3.
+- [Learning OJS 3: Authoring](https://docs.pkp.sfu.ca/learning-ojs/en/authoring) provides an overview of how to complete authoring tasks in OJS 3.
 
 ## Workflow for instructor (manager/editor)
 

--- a/learning-ojs/3.2/en/production-publication.md
+++ b/learning-ojs/3.2/en/production-publication.md
@@ -3,7 +3,7 @@ book: learning-ojs
 version: 3.2
 ---
 
-# Chapter 15: Production and Publication
+# Production and Publication
 
 With the completion of the Copyediting stage, the submission now moves to Production. From here, the copyedited files will be converted to publishable formats in the form of galley files (e.g., PDF, HTML) and proofread before publishing. A new journal issue will be created and the article will be scheduled for publication in the issue. This chapter explains the steps in that process, as well as how to use the versioning feature in OJS 3.2 to publish a new version of an article if significant changes are made.
 
@@ -482,7 +482,7 @@ This will reveal an **Edit** link, which will open a new window of information.
 
 **Table of Contents**: For a new issue, this will be empty, but for issues that have had submissions scheduled, they will be listed here.
 
-Use the blue arrow next to each submission to reveal links to go directly to the submission record (more about this in Chapter 10) or remove it.
+Use the blue arrow next to each submission to reveal links to go directly to the submission record or remove it.
 
 **Issue Data**: This provides access to the volume, issue, number data you entered when first creating the issue.
 

--- a/learning-ojs/3.2/en/settings-website.md
+++ b/learning-ojs/3.2/en/settings-website.md
@@ -86,7 +86,7 @@ To remove these fields and their contents from displaying publicly on the websit
 
 OJS is multilingual, which means that the interface, emails, and published content can be available in multiple languages on a single site or journal. When you install OJS, you can select one or more languages for your site.
 
-Under Website Settings > Languages you can see a list of languages or locales installed on your site and configure how the languages are used in your journal. Additional languages can be installed on your site by an Administrator – see [Chapter 4](./site-administration) for details.
+Under Website Settings > Languages you can see a list of languages or locales installed on your site and configure how the languages are used in your journal. Additional languages can be installed on your site by an Administrator – see [the Site Administration chapter](./site-administration) for details.
 
 ![OJS dashboard view of Languages menu with English and French options, English option selected as primary locale.](./assets/learning-ojs3.1-jm-settings-web-lang.png)
 

--- a/learning-ojs/en/production-publication.md
+++ b/learning-ojs/en/production-publication.md
@@ -491,7 +491,7 @@ This will reveal an **Edit** link, which will open a new window of information.
 
 **Table of Contents**: For a new issue, this will be empty, but for issues that have had submissions scheduled, they will be listed here.
 
-Use the blue arrow next to each submission to reveal links to go directly to the submission record (more about this in Chapter 10) or remove it.
+Use the blue arrow next to each submission to reveal links to go directly to the submission record or remove it.
 
 **Issue Data**: This provides access to the volume, issue, number data you entered when first creating the issue.
 

--- a/learning-ojs/en/settings-website.md
+++ b/learning-ojs/en/settings-website.md
@@ -112,7 +112,7 @@ Under Website Settings > Languages you can see a list of languages or locales in
 
 - **Submission**: If you want authors to be able to make submissions in other languages, select them here. This will allow authors to select a language when they make a submission and add metadata in selected languages when uploading their submission.
 
-Additional languages can be installed on your site by an Administrator – see [Chapter 4](./site-administration) for details.
+Additional languages can be installed on your site by an Administrator – see [the Site Administration chapter](./site-administration) for details.
 
 If enabling multiple languages to appear in the UI, make sure that in Website Settings > Appearance > Sidebar Management the Language Toggle Block is selected to make that feature available to users.
 

--- a/learning-omp/3.2/role-specific-workflows.md
+++ b/learning-omp/3.2/role-specific-workflows.md
@@ -211,7 +211,7 @@ Alternatively, they can also be uploaded in the __Publication Formats__ in Publi
 
 ### Contacting Author
 
-If your press will be sending proofs to the author for approval, you can use the Notify function in the Participants tab. See [Learning OJS - Chapter 15](/learning-ojs/en/production-publication#contact-the-author) for more details.
+If your press will be sending proofs to the author for approval, you can use the Notify function in the Participants tab. See [Learning OJS - Production and Publication](/learning-ojs/en/production-publication#contact-the-author) for more details.
 
 ### Publication Tabs
 

--- a/learning-omp/en/role-specific-workflows.md
+++ b/learning-omp/en/role-specific-workflows.md
@@ -211,7 +211,7 @@ Alternatively, they can also be uploaded in the __Publication Formats__ in Publi
 
 #### Contacting Author
 
-If your press will be sending proofs to the author for approval, you can use the Notify function in the Participants tab. See [Learning OJS - Chapter 15](/learning-ojs/en/production-publication#contact-the-author) for more details.
+If your press will be sending proofs to the author for approval, you can use the Notify function in the Participants tab. See [Learning OJS - Production and Publication](/learning-ojs/en/production-publication#contact-the-author) for more details.
 
 ### Publication Tabs
 


### PR DESCRIPTION
Remove references to numbered chapters in Learning OJS, which we removed in version 3.2.