### PR TITLE
Lighten blockquote colours to improve link contrast

### DIFF
--- a/_sass/components/book.scss
+++ b/_sass/components/book.scss
@@ -136,12 +136,12 @@
 		}
 
 		&.notice {
-			background: #d2eaf5;
+			background: #e6f3f9;
 			border-color: $link;
 		}
 
 		&.warning {
-			background: #f8dce2;
+			background: #fbeaed;
 			border-color: $warning;
 
 			code {


### PR DESCRIPTION
Slightly lighten the red/blue backgrounds for blockquote styles so that links will pass contrast requirements for accessibility (AA level).