### PR TITLE
"f" argument missing in tar call.

### DIFF
--- a/dev/upgrade-guide/en/index.md
+++ b/dev/upgrade-guide/en/index.md
@@ -205,7 +205,7 @@ Extract the release package.
 
 ```bash
 $ mkdir "$OJS_WEB_PATH"
-$ tar -xvz --strip-components=1 "$OJS_VERSION.tar.gz" -C "$OJS_WEB_PATH"
+$ tar --strip-components=1 -xvzf "$OJS_VERSION.tar.gz" -C "$OJS_WEB_PATH"
 ```
 
 Restore the `config.inc.php` file.


### PR DESCRIPTION
File argument is missing in the tar call.
When "f" is added tar expects a file so argument order need to be changed.