### PR TITLE
Fixed broken link in Upgrading from OJS 2 to 3

### DIFF
--- a/upgrading-ojs-2-to-3/en/differences.md
+++ b/upgrading-ojs-2-to-3/en/differences.md
@@ -18,7 +18,7 @@ For an overview of features you can look forward to seeing in OJS 3, see our [OJ
 
 ## OJS 3 interface
 
-There is a new interface for readers and editors, including a separate editorial interface that is visually distinct from the journal. Users with multiple roles are no longer required to select a role from their user homepage in order to access certain settings or administrative features; all the available options can be located in the new dashboard. This also allows for seamless switching between tasks associated with different roles. The new interface is illustrated below and explained in [What’s New in OJS 3](https://docs.pkp.sfu.ca/learning-ojs/en/introduction#whats-new-in-ojs-3).
+There is a new interface for readers and editors, including a separate editorial interface that is visually distinct from the journal. Users with multiple roles are no longer required to select a role from their user homepage in order to access certain settings or administrative features; all the available options can be located in the new dashboard. This also allows for seamless switching between tasks associated with different roles. The new interface is illustrated below and explained in [What's New in OJS 3](https://docs.pkp.sfu.ca/learning-ojs/3.2/en/introduction#whats-new-in-ojs-3).
 
 ![Dashboard menu in OJS 2.](./assets/ojs-2-settings.png) | ![Dashboard menu in OJS 3.](./assets/ojs-3-dashboard.png)
 :---: | :---:


### PR DESCRIPTION
The link was to a chapter in Learning OJS 3 called What's New in OJS 3. When the DIG updated Learning OJS 3 for OJS 3.3, they changed this chapter to "What's new in this version of OJS." I changed the link in the upgrading guide to the Learning OJS - 3.2 version, which still explains the differences between the OJS 2 and 3 interface.