### PR TITLE
Plugin inventory

### DIFF
--- a/_data/index.yml
+++ b/_data/index.yml
@@ -35,6 +35,7 @@ apps:
           isDeveloper: true
         - path: designing-your-journal
         - path: gdpr
+        - path: plugin-guides
         - path: translation
         - path: gfsf
   - path: ops3
@@ -48,6 +49,7 @@ apps:
           isDeveloper: true
         - path: designing-your-journal
         - path: gdpr
+        - path: plugin-guides
         - path: translation
         - path: faq
   - path: ojs2

--- a/_includes/cards/ojs3/plugin-guides.md
+++ b/_includes/cards/ojs3/plugin-guides.md
@@ -1,8 +1,9 @@
 
 ### Plugin Guides
 
-These guides explain how to use OJS plugins for DOIs, CrossRef, ORCID, and PayPal. The plugins integrate OJS with services offered by PKP partner organizations.
+These guides explain how to use OJS plugins. Plugins integrate OJS with services offered by PKP partner organizations.
 
+- [Plugin Inventory](/plugin-inventory/en/)
 - [DOI Plugin Guide](/doi-plugin/en/)
 - [Crossref Plugin Guide](/crossref-ojs-manual/en/)
 - [ORCID Plugin Guide](/orcid/en/)

--- a/_includes/cards/omp3/plugin-guides.md
+++ b/_includes/cards/omp3/plugin-guides.md
@@ -1,0 +1,7 @@
+
+### Plugin Guides
+
+These guides explain how to use OMP plugins. Plugins integrate OMP with services offered by PKP partner organizations.
+
+- [Plugin Inventory](/plugin-inventory/en/)
+- [PayPal Plugin Guide](/using-paypal-for-ojs-and-ocs/en/)

--- a/_includes/cards/ops3/plugin-guides.md
+++ b/_includes/cards/ops3/plugin-guides.md
@@ -1,0 +1,7 @@
+
+### Plugin Guides
+
+These guides explain how to use OPS plugins. Plugins integrate OPS with services offered by PKP partner organizations.
+
+- [Plugin Inventory](/plugin-inventory/en/)
+- [ORCID Plugin Guide](/orcid/en/)

--- a/plugin-inventory/en/README.md
+++ b/plugin-inventory/en/README.md
@@ -1,0 +1,6 @@
+---
+title: "About Plugins"
+description: The plugin inventory brings together links to existing plugin documentation for OJS/OMP/OPS. This list is not exhaustive and will continue to be updated as more plugin guides become available.
+---
+
+# About Plugins

--- a/plugin-inventory/en/SUMMARY.md
+++ b/plugin-inventory/en/SUMMARY.md
@@ -1,0 +1,4 @@
+# Summary
+
+* [About Plugins](.)
+* [Plugin Inventory](./inventory.md)

--- a/plugin-inventory/en/inventory.md
+++ b/plugin-inventory/en/inventory.md
@@ -404,7 +404,7 @@ Displays free altmetrics (an alternative to traditional citation-based metrics) 
 Supports the processing of payments the PayPal service. Payment types include author processing charges (single fee), reader fees (articles and issues), general fees.
 
 * [PayPal plugin guide](/using-paypal-for-ojs-and-ocs/en/)
-* [PayPal plugin guide](/learning-ojs/en/subscriptions#payments")
+* [PayPal instructions in Payments](/learning-ojs/en/subscriptions#payments)
 
 ## PDF.JS PDF Viewer
 

--- a/plugin-inventory/en/inventory.md
+++ b/plugin-inventory/en/inventory.md
@@ -1,5 +1,6 @@
 ---
 title: "Plugin Inventory"
+description: "An inventory of OJS, OMP, and OPS plugins, and their functions."
 ---
 
 # Plugin Inventory

--- a/plugin-inventory/en/inventory.md
+++ b/plugin-inventory/en/inventory.md
@@ -15,7 +15,7 @@ Attempts to reduce the dependance of the application on periodic scheduling tool
 
 Provides the addThis social media sharing on the articles abstract/landing page.
 
-* [AddThis Plugin in guide](/learning-ojs/en/settings-website#addthis-plugin)
+* [AddThis plugin guide](/learning-ojs/en/settings-website#addthis-plugin)
 
 ## Allowed Uploads
 
@@ -95,14 +95,14 @@ Applies a starter Bootstrap 3 theme. Knowledge of HTML, CSS and JavaScript will 
 
 Allows visitors to browse published articles by section in a journals sidebar or footer (depending on the theme).
 
-* [Browse By Section plugin in guide](/learning-ojs/en/settings-website#browse-plugin)
+* [Browse By Section plugin guide](/learning-ojs/en/settings-website#browse-plugin)
 * [Browse By Section plugin in GitHub](https://github.com/pkp/browseBySection)	
 
 ## Citation Style Language
 
 Allow readers to get a published article's citation in one of several formats supported by the Citation Style Language.
 
-* [Citation Style Language plugin in guide](/learning-ojs/en/settings-website#citation-style-language-plugin)
+* [Citation Style Language plugin guide](/learning-ojs/en/settings-website#citation-style-language-plugin)
 
 ## Clam Antivirus Plugin for OJS
 
@@ -114,7 +114,7 @@ Scans submission files using Clam Antivirus, blocking files with a known virus s
 
 An official theme for OJS 3 that applies that plays on colour and font contrasts based on literary classicism.
 
-* [Classic Theme plugin in guide](/pkp-theming-guide/en/theme-classic)	
+* [Classic Theme plugin guide](/pkp-theming-guide/en/theme-classic)	
 * [Classic Theme plugin in GitHub](https://github.com/pkp/classic)
 
 ## COinS
@@ -139,21 +139,21 @@ Allows journal and press managers to limit who can upload public files and what 
 
 Permits the addition of custom headers to the website, including custom JavaScript.
 
-* [Custom header plugin in guide](/learning-ojs/en/settings-website#custom-header-plugin)
+* [Custom header plugin guide](/learning-ojs/en/settings-website#custom-header-plugin)
 * [Custom header plugin in GitHub](/learning-ojs/en/settings-website#custom-header-plugin)
 
 ## Custom Locale
 
 Allows customization of message keys (field names, labels, links, etc.) in locale files via the GUI. The default locales are replaced but not overwritten and can easily be restored.
 
-* [Custom Local plugin in guide](/translating-guide/en/customize-locale)
+* [Custom Local plugin guide](/translating-guide/en/customize-locale)
 * [Custom Local Plugin in GitHub](https://github.com/pkp/customLocale/)	
 
 ## Datacite export for OJS
 
 Export or register issue, article, galley and supplementary file metadata in DataCite format.
 
-* [Datacite export plugin in guide](/admin-guide/en/data-import-and-export#datacite-exportregistration-plugin)
+* [Datacite export plugin guide](/admin-guide/en/data-import-and-export#datacite-exportregistration-plugin)
 * [Datacite export plugin in GitHub](https://github.com/pkp/ojs/tree/main/plugins/generic/datacite)	
 
 ## Datacite export for OMP
@@ -170,7 +170,7 @@ Structures metadata in a way that is consistent with the Dublin Core format.
 
 The default theme for OJS and OMP applies a simple, straightforward design. As of OJS/OMP/OPS 3.3, the Default Theme has been externally audited for accessibility and adheres to best practices like colour contrast, keyboard navigation, and form/link focus.
 
-* [Default theme plugin in guide](/pkp-theming-guide/en/theme-default)
+* [Default theme plugin guide](/pkp-theming-guide/en/theme-default)
 
 ## Developed By Block
 
@@ -180,25 +180,25 @@ Adds a link to [Open Journal Systems](https://pkp.sfu.ca/ojs/) in the sidebar.
 
 Integrates with Disqus and allows users to add comments to the abstract pages.
 
-* [Disqus plugin in guide](/learning-ojs/en/settings-website#custom-header-plugin)
+* [Disqus plugin guide](/learning-ojs/en/settings-website#custom-header-plugin)
 
 ## DOAJ Export Plugin
 
 Allows journals to manually or automatically deliver articles to the Directory of Open Access Journals (DOAJ) with a DOAJ API Key. Requires a journal to be DOAJ member - see [DOAJ application guide](/doaj/) for application instructions.
 
-* [DOAJ Export Plugin in guide](/admin-guide/en/data-import-and-export#doaj-export-plugin)
+* [DOAJ Export plugin guide](/admin-guide/en/data-import-and-export#doaj-export-plugin)
 
 ## DOI
 
 Enables the assignment of the Digital Object Identifiers to issues, articles and galleys in OJS. Can work in pair with Crossref, Datacite or Medra plugins for automatic content registration.
 
-* [DOI plugin in guide](/doi-plugin/en/)
+* [DOI plugin guide](/doi-plugin/en/)
 
 ## DOI to mEDRA xml export and registration
 
 Enables the export of issue, article and galley metadata in ONIX4DOI format and the registration of DOIs with mEDRA.
 
-* [mEDRA plugin in guide](/admin-guide/en/data-import-and-export#medra-exportregistration-plugin)
+* [mEDRA plugin guide](/admin-guide/en/data-import-and-export#medra-exportregistration-plugin)
 * [mEDRA plugin in GitHub](https://github.com/pkp/medra/)
 
 ## DRIVER
@@ -241,13 +241,13 @@ Integrates OJS with Google Analytics, Google's web site traffic analysis applica
 
 Enables indexing of published content in Google Scholar.
 
-* [Google Scholar plugin in guide](/google-scholar/en/)
+* [Google Scholar plugin guide](/google-scholar/en/)
 
 ## Health Sciences Theme
 
 An official theme for OJS 3 that applies designed to maximize legibility and content clarity, built with a focus on health sciences journals.
 
-* [Health Science Theme plugin in guide](/pkp-theming-guide/en/theme-healthsciences)
+* [Health Science Theme plugin guide](/pkp-theming-guide/en/theme-healthsciences)
 * [Health Science Theme plugin in GitHub](https://github.com/pkp/healthSciences)	
 
 ## Honeypot
@@ -264,14 +264,14 @@ Provides browser-based HTML Viewer for HTML Article Galleys.
 
 Adds Hypothes.is integration to the public article view, permitting annotation and commenting. It currently supports commenting on HTML galleys; see README for instructions on extending the functionality to PDF galleys.
 
-* [Hypothes.is plugin in guide](/learning-ojs/en/settings-website#hypothesis-plugin)
+* [Hypothes.is plugin guide](/learning-ojs/en/settings-website#hypothesis-plugin)
 * [Hypothes.is plugin in GitHub](https://github.com/asmecher/hypothesis)
 
 ## Immersion Theme
 
 An official theme for OJS 3 that emphasizes the reading experience and offers bold design options such as a full-width header image and per-section color choices.
 
-* [Immersion Theme plugin in guide](/pkp-theming-guide/en/theme-immersion)
+* [Immersion Theme plugin guide](/pkp-theming-guide/en/theme-immersion)
 * [Immersion Theme plugin in GitHub](https://github.com/pkp/immersion)
 
 ## Information Block
@@ -294,7 +294,7 @@ Permits OJS to use a basic JATS XML document generated from the OJS metadata and
 
 Provide a tag cloud of article keywords that can be added to a journals sidebar.
 
-* [Keyword plugin in guide](/learning-ojs/en/settings-website#keyword-cloud-plugin)
+* [Keyword plugin guide](/learning-ojs/en/settings-website#keyword-cloud-plugin)
 * [Keyword plugin in GitHub](https://github.com/lepidus/ojs3-keywordcloud-plugin)
 
 ## Language Toggle Block
@@ -321,13 +321,13 @@ Provides a sidebar block with a "Make a Submission" link.
 
 Allows the manager to manually record receipt of a user's payment (outside of this software).
 
-* [Manual Fee Payment plugin in guide](/learning-ojs/en/subscriptions#payments)
+* [Manual Fee Payment plugin guide](/learning-ojs/en/subscriptions#payments)
 
 ## Manuscript (Default child theme)
 
 Applies a clean, simple theme with a boxed layout that mimics a paper document.
 
-* [Manuscript theme plugin in guide](/pkp-theming-guide/en/theme-manuscript)
+* [Manuscript theme plugin guide](/pkp-theming-guide/en/theme-manuscript)
 * [Manuscript theme plugin in GitHub](https://github.com/NateWr/defaultManuscript)
 
 ## MARC Metadata Format
@@ -354,13 +354,13 @@ Permits usage statistics tracking using Matomo (formerly Piwik).
 
 Creates a “most read articles” section in the journal’s sidebar with the 5 most viewed articles (with links) in the last week, along with the number of views per article.
 
-* [Most read plugin in guide](/learning-ojs/en/settings-website#most-read-plugin)
+* [Most read plugin guide](/learning-ojs/en/settings-website#most-read-plugin)
 
 ## Native XML
 
 Allows import and export of articles and issues in OJS's native XML format between the same OJS versions.
 
-* [Native XML plugin in guide](/admin-guide/en/data-import-and-export#native-xml-plugin)
+* [Native XML plugin guide](/admin-guide/en/data-import-and-export#native-xml-plugin)
 
 ## OAI JATS
 
@@ -390,7 +390,7 @@ Enables users to log in to PKP applications using OpenID Connect providers. It c
 
 Allows users to automatically import user profile data from the ORCID profile into OJS with their ORCID ID.
 
-* [ORCID Profile plugin in guide](/orcid/en/)
+* [ORCID Profile plugin guide](/orcid/en/)
 * [ORCID Profile plugin in GitHub](https://github.com/pkp/orcidProfile)
 
 ## Paperbuzz
@@ -403,8 +403,8 @@ Displays free altmetrics (an alternative to traditional citation-based metrics) 
 
 Supports the processing of payments the PayPal service. Payment types include author processing charges (single fee), reader fees (articles and issues), general fees.
 
-* [PayPal plugin in guide](/using-paypal-for-ojs-and-ocs/en/)
-* [PayPal plugin in guide](/learning-ojs/en/subscriptions#payments")
+* [PayPal plugin guide](/using-paypal-for-ojs-and-ocs/en/)
+* [PayPal plugin guide](/learning-ojs/en/subscriptions#payments")
 
 ## PDF.JS PDF Viewer
 
@@ -414,13 +414,13 @@ Provides browser-based viewer for article and issue galleys in PDF.
 
 Generates a CSV spreadsheet containing monthly views for the journal homepage; issue TOCs; article abstract/landing pages; and file downloads. It can provides country information (if configured).
 
-* [Usage Statistics Report plugin in guide](/learning-ojs/en/statistics#usage-statistics-report)
+* [Usage Statistics Report plugin guide](/learning-ojs/en/statistics#usage-statistics-report)
 
 ## PKP|PN
 
 Enables the automatic preservation of published journal content in the [PKP Preservation Network](https://pkp.sfu.ca/pkp-pn/) (PKP|PN). This plugin requires [ZipArchive](https://www.php.net/manual/en/zip.installation.php) support.
 
-* [PKP PN plugin in guide](/pkp-pn/en/)
+* [PKP PN plugin guide](/pkp-pn/en/)
 * [PKP PN plugin in GitHub](https://github.com/pkp/pln)
 
 ## Plugins update notification
@@ -463,7 +463,7 @@ Enables integration with Publons Reviewer Recognition Service. This plugin will 
 
 Export article metadata in PubMed XML format for journals indexed in MEDLINE.
 
-* [PubMed XML Export plugin in guide](/admin-guide/en/data-import-and-export#pubmed-xml-export-plugin)
+* [PubMed XML Export plugin guide](/admin-guide/en/data-import-and-export#pubmed-xml-export-plugin)
 
 ## PURL
 
@@ -475,20 +475,20 @@ Enables the assignation and management of persistent uniform resource locator (P
 
 Permits Journal Managers/Editors to quickly enter submissions through the OJS website, bypassing the editorial workflow.
 
-* [QuickSubmit plugin in guide](/learning-ojs/en/tools#quick-submit-plugin)
+* [QuickSubmit plugin guide](/learning-ojs/en/tools#quick-submit-plugin)
 * [QuickSubmit plugin in GitHub](https://github.com/pkp/quickSubmit)
 
 ## Recommend Articles by Author
 
 Inserts a list of articles by the same author on the article abstract/landing page.
 
-* [Recommended Articles plugin in guide](/learning-ojs/en/settings-website#recommend-articles-by-author-plugin)
+* [Recommended Articles plugin guide](/learning-ojs/en/settings-website#recommend-articles-by-author-plugin)
 
 ## Recommend Similar Articles
 
 Adds a list of similar articles to the bottom of the articles abstract/landing page.
 
-* [Recommended Similar Articles plugin in guide](/learning-ojs/en/settings-website#recommend-similar-articles-plugin) 
+* [Recommended Similar Articles plugin guide](/learning-ojs/en/settings-website#recommend-similar-articles-plugin) 
 
 ## Registration Notification
 
@@ -540,7 +540,7 @@ Adds social media buttons to your web site (to the footer of each page or the si
 
 Adds an ability to use shibboleth single sign-on service to register and authenticate users. You must have set up and configured the local service provider (SP).
 
-* [Shibboleth plugin in guide](/admin-guide/en/single-signon#setting-up-shibboleth)
+* [Shibboleth plugin guide](/admin-guide/en/single-signon#setting-up-shibboleth)
 * [Shibboleth plugin in GitHub](https://github.com/pkp/shibboleth)
 
 ## Sitesearch
@@ -553,7 +553,7 @@ Allows searches done in one journal (within a multi-journal installation) to be 
 
 Provides sidebar subscription information in journals with enabled subscriptions.
 
-* [Subscription Block plugin in guide](/learning-ojs/en/subscriptions#subscription-block)
+* [Subscription Block plugin guide](/learning-ojs/en/subscriptions#subscription-block)
 
 ## Subscription SSO
 
@@ -565,7 +565,7 @@ Permits delegation of OJS subscription checks to a third-party web service.
 
 Generates a CSV spreadsheet containing a list of subscriptions and their information. This report provides subscription status, type, format, dates, and subscriber information.
 
-* [Subscription Report plugin in guide](/learning-ojs/en/statistics#usage-statistics-report)
+* [Subscription Report plugin guide](/learning-ojs/en/statistics#usage-statistics-report)
 
 ## Suggested Reviewers Plugin by Ubiquity Press (unvetted)
 
@@ -625,13 +625,13 @@ Enables the assignment of the Uniform Resource Names to the issues, articles and
 
 Displays the number of article downloads on the article page, in bar or line graph format. Requires Administrator access to be enabled or disabled.
 
-* [Usage Statistics plugin in guide](/learning-ojs/en/settings-website#usage-statistics-plugin)
+* [Usage Statistics plugin guide](/learning-ojs/en/settings-website#usage-statistics-plugin)
 
 ## Users XML
 
 Allows import and export of users and their roles between the same OJS versions.
 
-* [Users XML plugin in guide](/admin-guide/en/data-import-and-export#export-users-to-xml)
+* [Users XML plugin guide](/admin-guide/en/data-import-and-export#export-users-to-xml)
 
 ## View Report
 

--- a/plugin-inventory/en/inventory.md
+++ b/plugin-inventory/en/inventory.md
@@ -4,447 +4,640 @@ title: "Plugin Inventory"
 
 # Plugin Inventory
 
-This inventory page provides a short description of the plugins function. If applicable, it will also provide a link to additional documentation and direct links to the plugins Github page. Plugins not in the Plugin Gallery in OJS 3.2 or 3.3 will be marked as “unvetted” on the list. 
+This inventory page provides a short description of the plugins function. If applicable, it will also provide a link to additional documentation and direct links to the plugin's GitHub page. Plugins not in the Plugin Gallery in OJS 3.2 or 3.3 will be marked as “unvetted” on the list. 
 
-## Acron 
+## Acron
+
 Attempts to reduce the dependance of the application on periodic scheduling tools such as 'cron.' Once enabled, this plugin should result in the processing of log files (along with other scheduled tasks, such as review and subscription reminders).
 
 ## AddThis
-Provides the addThis social media sharing on the articles abstract/landing page. 
-* [AddThis Plugin in guide](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#addthis-plugin)
+
+Provides the addThis social media sharing on the articles abstract/landing page.
+
+* [AddThis Plugin in guide](/learning-ojs/en/settings-website#addthis-plugin)
 
 ## Allowed Uploads
-Enables journals to choose the filetypes that are allowed when submitting a manuscript.
-* [Allowed plugin in Github](https://github.com/ajnyga/allowedUploads)
 
-## Announcement Feed 
+Enables journals to choose the filetypes that are allowed when submitting a manuscript.
+
+* [Allowed plugin in GitHub](https://github.com/ajnyga/allowedUploads)
+
+## Announcement Feed
+
 Produces RSS/Atom web syndication feeds for journal announcements.
-* [Announcement Block Plugin in Github](https://github.com/RBoelter/announcementsBlock) 
+
+* [Announcement Block Plugin in GitHub](https://github.com/RBoelter/announcementsBlock)
 
 ## Ark
+
 Enables the assignation and management of ARK ID to issue, article and galley.
-* [Ark Plugin in Github](https://github.com/yasielpv/pkp-ark-pubid)
+
+* [Ark Plugin in GitHub](https://github.com/yasielpv/pkp-ark-pubid)
 
 ## Articles Report
-Generates a CSV spreadsheet containing a list of articles (published and unpublished), including the submission ID, title, abstract, author information, current status, and more.
-* [Article Report in guide](https://docs.pkp.sfu.ca/learning-ojs/en/statistics#usage-statistics-report)
 
-## Askimet
+Generates a CSV spreadsheet containing a list of articles (published and unpublished), including the submission ID, title, abstract, author information, current status, and more.
+
+* [Article Report in guide](/learning-ojs/en/statistics#usage-statistics-report)
+
+## Akismet
+
 Verifies new user registrations via the Akismet anti-spam service. A subscription to Akismet is required for this plugin.
-* [Askimet plugin in Github](https://github.com/ulsdevteam/pkp-akismet)
+
+* [Akismet plugin in GitHub](https://github.com/ulsdevteam/pkp-akismet)
 
 ## Author Requirements
-Allows certain author fields (e.g., email) to be made optional. This is useful in cases where required information does not exist for authors.
-* [Author Requirement plugin in Github](https://github.com/ewhanson/authorRequirements)
 
-## Authors History		
+Allows certain author fields (e.g., email) to be made optional. This is useful in cases where required information does not exist for authors.
+
+* [Author Requirement plugin in GitHub](https://github.com/ewhanson/authorRequirements)
+
+## Authors History
+
 Generates an additional tab within the manuscripts Publication tab and lists additional submissions in the system from each contributor.
-* [Authors History plugin in Github](https://github.com/lepidus/authorsHistory)
+
+* [Authors History plugin in GitHub](https://github.com/lepidus/authorsHistory)
 
 ## Backup
-Allows site administators to generate and download a full backup of the various components of thier OJS 3.x/OMP/OPS installation.
-* [Backup plugin in Github](https://github.com/asmecher/backup)
 
-## Bepress Import  (unvetted)
+Allows site administrators to generate and download a full backup of the various components of their OJS 3.x/OMP/OPS installation.
+
+* [Backup plugin in GitHub](https://github.com/asmecher/backup)
+
+## Bepress Import (unvetted)
+
 Facilitates the import from Bepress Digital Commons journals to OJS 3.1.1 or newer.
-* [Bepress plugin in Github](https://github.com/mfelczak/bepress)
+
+* [Bepress plugin in GitHub](https://github.com/mfelczak/bepress)
 * [Migrating bepress Digital Commons Journals to OJS](https://pkp.sfu.ca/2017/12/07/migrating-bepress-digital-commons-journals-to-ojs/)
 
-## Better Password		
-Provides additional password restriction options when users are selecting their own password.
-* [Better Password plugin in Github](https://github.com/ulsdevteam/pkp-betterPassword)
+## Better Password
 
-## Bibi Epub Viewer		
+Provides additional password restriction options when users are selecting their own password.
+
+* [Better Password plugin in GitHub](https://github.com/ulsdevteam/pkp-betterPassword)
+
+## Bibi Epub Viewer
+
 Embeds EPUb files on the article galley view for OJS and OMP using Bibi Epub Reader.
 
-* [Bibi Epub Viewer plugin in Github](https://github.com/lepidus/epubViewer)
+* [Bibi Epub Viewer plugin in GitHub](https://github.com/lepidus/epubViewer)
 
-## Bootstrap3 Theme		
-Applies a starter Bootstrap 3 theme. Knowledge of HTML, CSS and JavaScript will be needed for this theme as it is designed to be a base and not a final product. 
-* [Bootstrap3 Theme in guide](https://docs.pkp.sfu.ca/pkp-theming-guide/en/theme-bootstrap3)	
-* [Bootstrap3 Theme in Github](https://github.com/NateWr/bootstrap3)
+## Bootstrap3 Theme
 
-## Browse By Section 		
+Applies a starter Bootstrap 3 theme. Knowledge of HTML, CSS and JavaScript will be needed for this theme as it is designed to be a base and not a final product.
+
+* [Bootstrap3 Theme in guide](/pkp-theming-guide/en/theme-bootstrap3)
+* [Bootstrap3 Theme in GitHub](https://github.com/NateWr/bootstrap3)
+
+## Browse By Section
+
 Allows visitors to browse published articles by section in a journals sidebar or footer (depending on the theme).
-* [Browse By Section plugin in guide](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#browse-plugin)	
-* [Browse By Section plugin in Github](https://github.com/pkp/browseBySection)	
 
+* [Browse By Section plugin in guide](/learning-ojs/en/settings-website#browse-plugin)
+* [Browse By Section plugin in GitHub](https://github.com/pkp/browseBySection)	
 
-## Citation Style Language	
-Allow readers to get a published article's citation in one of several formats supported by the Citation Style Language. 
-* [Citation Style Language plugin in guide](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#citation-style-language-plugin)
+## Citation Style Language
 
-## Clam Antivirus Plugin for OJS		
+Allow readers to get a published article's citation in one of several formats supported by the Citation Style Language.
+
+* [Citation Style Language plugin in guide](/learning-ojs/en/settings-website#citation-style-language-plugin)
+
+## Clam Antivirus Plugin for OJS
+
 Scans submission files using Clam Antivirus, blocking files with a known virus signature.
-* [Clam Antivirus plugin in Github](https://github.com/ulsdevteam/pkp-clamav)	
 
-## Classic Theme	
+* [Clam Antivirus plugin in GitHub](https://github.com/ulsdevteam/pkp-clamav)
+
+## Classic Theme
+
 An official theme for OJS 3 that applies that plays on colour and font contrasts based on literary classicism.
-* [Classic Theme plugin in guide](https://docs.pkp.sfu.ca/pkp-theming-guide/en/theme-classic)	
-* [Classic Theme plugin in Github](https://github.com/pkp/classic)
 
-## COinS		
+* [Classic Theme plugin in guide](/pkp-theming-guide/en/theme-classic)	
+* [Classic Theme plugin in GitHub](https://github.com/pkp/classic)
+
+## COinS
+
 Embeds OpenURL COinS in OJS articles permitting tools like Zotero to grab citations.
-* [COinS plugin in Github](https://github.com/pkp/coins)
 
-## Content Analysis	
+* [COinS plugin in GitHub](https://github.com/pkp/coins)
+
+## Content Analysis
+
 Checks the content of the submitted document for certain submission information and metadata for OPS
-* [Content Analysis plugin in Github](https://github.com/lepidus/contentAnalysis)
 
-## Control Public Files		
+* [Content Analysis plugin in GitHub](https://github.com/lepidus/contentAnalysis)
+
+## Control Public Files
+
 Allows journal and press managers to limit who can upload public files and what kind of files they can upload. Provides settings to restrict who can upload, what kind of files they can upload, and how large their directory of files can grow.
-* [Control Public Files plugin in Github](https://github.com/pkp/controlPublicFiles)	
+
+* [Control Public Files plugin in GitHub](https://github.com/pkp/controlPublicFiles)
 
 ## Custom Header Plugin
+
 Permits the addition of custom headers to the website, including custom JavaScript.
-* [Custom header plugin in guide](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#custom-header-plugin)
-* [Custom header plugin in Github](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#custom-header-plugin)
 
-## Custom Locale	
-Allows customization of message keys (field names, labels, links, etc.) in locale files via the GUI. The default locales are replaced but not overwritten and can easily be restored. 
-* [Custom Local plugin in guide](https://docs.pkp.sfu.ca/translating-guide/en/customize-locale	)
-* [Custom Local Plugin in Github](https://github.com/pkp/customLocale/)	
+* [Custom header plugin in guide](/learning-ojs/en/settings-website#custom-header-plugin)
+* [Custom header plugin in GitHub](/learning-ojs/en/settings-website#custom-header-plugin)
 
+## Custom Locale
 
-## Datacite export for OJS	
+Allows customization of message keys (field names, labels, links, etc.) in locale files via the GUI. The default locales are replaced but not overwritten and can easily be restored.
+
+* [Custom Local plugin in guide](/translating-guide/en/customize-locale)
+* [Custom Local Plugin in GitHub](https://github.com/pkp/customLocale/)	
+
+## Datacite export for OJS
+
 Export or register issue, article, galley and supplementary file metadata in DataCite format.
-* [Datacite export plugin in guide](https://docs.pkp.sfu.ca/admin-guide/en/data-import-and-export#datacite-exportregistration-plugin)	
-* [Datacite export plugin in Github](https://github.com/pkp/ojs/tree/main/plugins/generic/datacite)	
 
-## Datacite export for OMP		
-Registers DOIS for monographs and chapters for DOI provider Datacite.
-* [Datacite export plugin in Github](https://github.com/withanage/datacite)
+* [Datacite export plugin in guide](/admin-guide/en/data-import-and-export#datacite-exportregistration-plugin)
+* [Datacite export plugin in GitHub](https://github.com/pkp/ojs/tree/main/plugins/generic/datacite)	
 
-## DC Metadata Format			
+## Datacite export for OMP
+
+Registers DOIs for monographs and chapters for DOI provider Datacite.
+
+* [Datacite export plugin in GitHub](https://github.com/withanage/datacite)
+
+## DC Metadata Format
+
 Structures metadata in a way that is consistent with the Dublin Core format.
 
-## Default Theme	
-The default theme for OJS and OMP applies a simple, straightwordward design. As of OJS/OMP/OPS 3.3, the Default Theme has been externally audited for accessibility and adheres to best practices like colour contrast, keyboard navigation, and form/link focus.
-* [Default theme plugin in guide](https://docs.pkp.sfu.ca/pkp-theming-guide/en/theme-default)
+## Default Theme
 
-## Developed By Block			
+The default theme for OJS and OMP applies a simple, straightforward design. As of OJS/OMP/OPS 3.3, the Default Theme has been externally audited for accessibility and adheres to best practices like colour contrast, keyboard navigation, and form/link focus.
+
+* [Default theme plugin in guide](/pkp-theming-guide/en/theme-default)
+
+## Developed By Block
+
 Adds a link to [Open Journal Systems](https://pkp.sfu.ca/ojs/) in the sidebar.
 
 ## Disqus
+
 Integrates with Disqus and allows users to add comments to the abstract pages.
-* [Disquis plugin in guide](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#custom-header-plugin)
 
-## DOAJ Export Plugin		
-Allows journals to manually or automatically deliver articles to the Directory of Open Access Journals (DOAJ) with a DOAJ API Key. Requires a journal to be DOAJ member - see [DOAJ application guide](https://docs.pkp.sfu.ca/doaj/) for application instructions.
+* [Disqus plugin in guide](/learning-ojs/en/settings-website#custom-header-plugin)
 
-* [DOAJ Export Plugin in guide](https://docs.pkp.sfu.ca/admin-guide/en/data-import-and-export#doaj-export-plugin)
+## DOAJ Export Plugin
 
-## DOI	
+Allows journals to manually or automatically deliver articles to the Directory of Open Access Journals (DOAJ) with a DOAJ API Key. Requires a journal to be DOAJ member - see [DOAJ application guide](/doaj/) for application instructions.
+
+* [DOAJ Export Plugin in guide](/admin-guide/en/data-import-and-export#doaj-export-plugin)
+
+## DOI
+
 Enables the assignment of the Digital Object Identifiers to issues, articles and galleys in OJS. Can work in pair with Crossref, Datacite or Medra plugins for automatic content registration.
-* [DOI plugin in guide](https://docs.pkp.sfu.ca/doi-plugin/en/)
 
-## DOI to mEDRA xml export and registration 
+* [DOI plugin in guide](/doi-plugin/en/)
+
+## DOI to mEDRA xml export and registration
+
 Enables the export of issue, article and galley metadata in ONIX4DOI format and the registration of DOIs with mEDRA.
-* [mEDRA plugin in guide](https://docs.pkp.sfu.ca/admin-guide/en/data-import-and-export#medra-exportregistration-plugin)	
-* [mEDRA plugin in Github](https://github.com/pkp/medra/)
 
-## DRIVER			
+* [mEDRA plugin in guide](/admin-guide/en/data-import-and-export#medra-exportregistration-plugin)
+* [mEDRA plugin in GitHub](https://github.com/pkp/medra/)
+
+## DRIVER
+
 Extends the OAI-PMH interface according to the DRIVER Guidelines 2.0, helping OJS journals to become DRIVER compliant.
 
-## Dublin Core Indexing 		
+## Dublin Core Indexing
+
 Embeds Dublin Core meta tags in article views for indexing purposes.
 
-## Email Issue Table of Contents			
+## Email Issue Table of Contents
+
 Embeds the table of contents within the default notification email sent when publishing an issue.
-* [Email Issues TOC plugin in Gitbub](https://github.com/ulsdevteam/pkp-emailIssueToc)
 
-## EPUB viewer		
+* [Email Issues TOC plugin in GitHub](https://github.com/ulsdevteam/pkp-emailIssueToc)
+
+## EPUB viewer
+
 Embeds EPUB files on the article galley view pages using epub.js.
-* [EPUB viewer plugin in Github](https://github.com/EKT/epubJsViewer-ojs)
 
-## Forthcoming articles (unvetted)		
+* [EPUB viewer plugin in GitHub](https://github.com/EKT/epubJsViewer-ojs)
+
+## Forthcoming articles (unvetted)
+
 Allows journals to preview single articles on their website before an entire issue is published.Hides the Forthcoming issue from the regular issue archive and redirect all traffic from the issue table of contents page to the custom Forthcoming listing page.
-* [Forthcoming articles plugin in Github](https://github.com/ajnyga/forthcoming)
 
-## Funding 		
+* [Forthcoming articles plugin in GitHub](https://github.com/ajnyga/forthcoming)
+
+## Funding
+
 Adds submission funding data using the Crossref funders registry, considers the data in the Crossref and DataCite XML export and displays them on the submission view page.
-* [Funding plugin in Github](https://github.com/ajnyga/funding/)
 
-## Google Analytics 			
+* [Funding plugin in GitHub](https://github.com/ajnyga/funding/)
+
+## Google Analytics
+
 Integrates OJS with Google Analytics, Google's web site traffic analysis application. Requires that you have already setup a Google Analytics account. See Google Analytics site for more information.
 
-## Google Scholar Indexing 
+## Google Scholar Indexing
+
 Enables indexing of published content in Google Scholar.
-* [Google Scholar plugin in guide](https://docs.pkp.sfu.ca/google-scholar/en/)
 
-## Health Sciences Theme	
+* [Google Scholar plugin in guide](/google-scholar/en/)
+
+## Health Sciences Theme
+
 An official theme for OJS 3 that applies designed to maximize legibility and content clarity, built with a focus on health sciences journals.
-* [Health Science Theme plugin in guide](https://docs.pkp.sfu.ca/pkp-theming-guide/en/theme-healthsciences)	
-*  [Health Science Theme plugin in Github](https://github.com/pkp/healthSciences)	
 
-## Honeypot		
+* [Health Science Theme plugin in guide](/pkp-theming-guide/en/theme-healthsciences)
+* [Health Science Theme plugin in GitHub](https://github.com/pkp/healthSciences)	
+
+## Honeypot
+
 Verifies new user registrations by creating a honeypot on the User Registration form. This plugin operates at the site level and requires Site Administrator privileges to configure.
-* [Honeypot plugin in Github](https://github.com/ulsdevteam/pkp-formHoneypot)
 
-## HTML Article Galley			
+* [Honeypot plugin in GitHub](https://github.com/ulsdevteam/pkp-formHoneypot)
+
+## HTML Article Galley
+
 Provides browser-based HTML Viewer for HTML Article Galleys.
 
-## Hypothes.is	
+## Hypothes.is
+
 Adds Hypothes.is integration to the public article view, permitting annotation and commenting. It currently supports commenting on HTML galleys; see README for instructions on extending the functionality to PDF galleys.
-* [Hypothes.is plugin in guide](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#hypothesis-plugin)
-* [Hypothes.is plugin in Github](https://github.com/asmecher/hypothesis)
+
+* [Hypothes.is plugin in guide](/learning-ojs/en/settings-website#hypothesis-plugin)
+* [Hypothes.is plugin in GitHub](https://github.com/asmecher/hypothesis)
 
 ## Immersion Theme
-An official theme for OJS 3 that emphasizes the reading experience and offers bold design options such as a full-width header image and per-section color choices.
-* [Immersion Theme plugin in guide](https://docs.pkp.sfu.ca/pkp-theming-guide/en/theme-immersion)
-* [Immersion Theme plugin in Github](https://github.com/pkp/immersion)
 
-## Information Block			
+An official theme for OJS 3 that emphasizes the reading experience and offers bold design options such as a full-width header image and per-section color choices.
+
+* [Immersion Theme plugin in guide](/pkp-theming-guide/en/theme-immersion)
+* [Immersion Theme plugin in GitHub](https://github.com/pkp/immersion)
+
+## Information Block
+
 Provides sidebar information block with 3 sections: For Readers, For Authors, For Librarians. Standard text for these sections can be edited in Website > Setup > Information
 
-## iThenticate		
+## iThenticate
+
 Permits automatic submission of all uploaded files to the iThenticate service for plagiarism checking. This plugin will require an iThenticate account to be set up.
-* [iThenticate plugin Github](https://github.com/asmecher/plagiarism)
 
-## JATS Template 	
+* [iThenticate plugin GitHub](https://github.com/asmecher/plagiarism)
+
+## JATS Template
+
 Permits OJS to use a basic JATS XML document generated from the OJS metadata and full-text extraction in cases where a better JATS XML document is not available. It is intended to be used in concert with the OAI JATS plugin to deliver JATS via OAI for journals that do not have better JATS XML available.
-* [JATS Template plugin in Github](https://github.com/pkp/jatsTemplate/)
 
-## Keyword Cloud Plugin	
+* [JATS Template plugin in GitHub](https://github.com/pkp/jatsTemplate/)
+
+## Keyword Cloud Plugin
+
 Provide a tag cloud of article keywords that can be added to a journals sidebar.
-* [Keyword plugin in guide](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#keyword-cloud-plugin)
-* [Keyword plugin in Github](https://github.com/lepidus/ojs3-keywordcloud-plugin)
 
-## Language Toggle Block			
+* [Keyword plugin in guide](/learning-ojs/en/settings-website#keyword-cloud-plugin)
+* [Keyword plugin in GitHub](https://github.com/lepidus/ojs3-keywordcloud-plugin)
+
+## Language Toggle Block
+
 Provides the sidebar language toggler. More than one language needs to be enabled for it to work, in Website > Setup > Languages
 
-## Lens Viewer for Monographs and Journal Articles		
+## Lens Viewer for Monographs and Journal Articles
+
 Provides browser-based HTML Viewer for Journal Articles and Monographs based on JATS-standard XML files.
-* [Lens Viewer plugin in Github](https://github.com/withanage/lensGalleyBits)
 
-## Lucene/Solr Plugin			
-Integrates the solr/search for OJS journals. Integration requires additional configuration and it is recommended to test on a test installation, before using on a production server. 
-* [Lucene/Solr plugin in Github](https://github.com/ojsde/lucene)
+* [Lens Viewer plugin in GitHub](https://github.com/withanage/lensGalleyBits)
 
-## Make a Submission Block			
+## Lucene/Solr Plugin
+
+Integrates the solr/search for OJS journals. Integration requires additional configuration and it is recommended to test on a test installation, before using on a production server.
+
+* [Lucene/Solr plugin in GitHub](https://github.com/ojsde/lucene)
+
+## Make a Submission Block
+
 Provides a sidebar block with a "Make a Submission" link.
 
-## Manual Fee Payment	
-Allows the manager to manually record receipt of a user's payment (outside of this software).
-* [Manual Fee Payment plugin in guide](https://docs.pkp.sfu.ca/learning-ojs/en/subscriptions#payments)
+## Manual Fee Payment
 
-## Manuscript (Default child theme)	
+Allows the manager to manually record receipt of a user's payment (outside of this software).
+
+* [Manual Fee Payment plugin in guide](/learning-ojs/en/subscriptions#payments)
+
+## Manuscript (Default child theme)
+
 Applies a clean, simple theme with a boxed layout that mimics a paper document.
 
-* [Manuscript theme plugin in guide](https://docs.pkp.sfu.ca/pkp-theming-guide/en/theme-manuscript)
-* [Manuscript theme plugin in Github](https://github.com/NateWr/defaultManuscript)
+* [Manuscript theme plugin in guide](/pkp-theming-guide/en/theme-manuscript)
+* [Manuscript theme plugin in GitHub](https://github.com/NateWr/defaultManuscript)
 
-## MARC Metadata Format			
+## MARC Metadata Format
+
 Structures metadata in a way that is consistent with the MARC format.
 
-## MARC21 Metadata Format			
+## MARC21 Metadata Format
+
 Structures metadata in a way that is consistent with the MARC21 format.
 
-## Material Theme		
+## Material Theme
+
 Applies Material Theme (MDBootstrap based) theme for the reader frontend.
-* [Material Theme plugin in Github](https://github.com/madi-nuralin/material)
 
-## Matomo		
-Permits usage statistics tracking using Matomo (formerly Piwik) - for Matomo customers.
-* [Matamo plugin in Github](https://github.com/pkp/piwik)
+* [Material Theme plugin in GitHub](https://github.com/madi-nuralin/material)
 
-## Most read	
+## Matomo
+
+Permits usage statistics tracking using Matomo (formerly Piwik).
+
+* [Matomo plugin in GitHub](https://github.com/pkp/piwik)
+
+## Most read
+
 Creates a “most read articles” section in the journal’s sidebar with the 5 most viewed articles (with links) in the last week, along with the number of views per article.
-* [Most read plugin in guide](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#most-read-plugin)
 
-## Native XML 
+* [Most read plugin in guide](/learning-ojs/en/settings-website#most-read-plugin)
+
+## Native XML
+
 Allows import and export of articles and issues in OJS's native XML format between the same OJS versions.
-* [Native XML plugin in guide](https://docs.pkp.sfu.ca/admin-guide/en/data-import-and-export#native-xml-plugin)
+
+* [Native XML plugin in guide](/admin-guide/en/data-import-and-export#native-xml-plugin)
 
 ## OAI JATS
+
 Exposes JATS XML via the OAI-PMH interface. Note that it DOES NOT generate JATS XML itself -- it assumes that this will already be available.
-* [OAI JATS plugin in Github](https://github.com/pkp/oaiJats/)
 
-## Open Graph 	
-Open Graph Plugin presents published content using the Open Graph protocol. Open Graph tags are used when you content is shared in Facebook
-* [Open Graph plugin in Github](https://github.com/ajnyga/openGraph)
+* [OAI JATS plugin in GitHub](https://github.com/pkp/oaiJats/)
 
-## OpenAIRE		
+## Open Graph
+
+Open Graph Plugin presents published content using the Open Graph protocol. Open Graph tags are used when you content is shared in Facebook.
+
+* [Open Graph plugin in GitHub](https://github.com/ajnyga/openGraph)
+
+## OpenAIRE
+
 Adds the ProjectID element to the article metadata and extends the OAI-PMH interface according to the OpenAIRE Guidelines 1.1, helping OJS journals to become OpenAIRE compliant.
-* [OpenAIRE plugin in Github](https://github.com/ojsde/openAIRE)
 
-## OpenID Authentication 	
-Enables users to log in to PKP applications using OpenID Connect providers. It currently supports Google, Apple ID, Microsoft Azure AD and Orchid. It is also possible to configure a custom OpenID Connect provider such as Keycloak. 
-* [Open ID Authentication plugin in Github](https://github.com/leibniz-psychology/openid)
+* [OpenAIRE plugin in GitHub](https://github.com/ojsde/openAIRE)
 
-## ORCID Profile 	
-Allows users to automatically import user profile data from the ORCID profile into OJS with their ORCID ID. 
-* [ORCID Profile plugin in guide](https://docs.pkp.sfu.ca/orcid/en/)	
-* [ORCID Profile plugin in Github](https://github.com/pkp/orcidProfile)
+## OpenID Authentication
 
-## Paperbuzz		
+Enables users to log in to PKP applications using OpenID Connect providers. It currently supports Google, Apple ID, Microsoft Azure AD and Orchid. It is also possible to configure a custom OpenID Connect provider such as Keycloak.
+
+* [Open ID Authentication plugin in GitHub](https://github.com/leibniz-psychology/openid)
+
+## ORCID Profile
+
+Allows users to automatically import user profile data from the ORCID profile into OJS with their ORCID ID.
+
+* [ORCID Profile plugin in guide](/orcid/en/)
+* [ORCID Profile plugin in GitHub](https://github.com/pkp/orcidProfile)
+
+## Paperbuzz
+
 Displays free altmetrics (an alternative to traditional citation-based metrics) based on open Crossref Event data. To use this plugin, your journal must have DOIs assigned to articles and properly deposited with Crossref. 
 
-* [Paperbuzz plugin in Github](https://github.com/pkp/paperbuzz)
+* [Paperbuzz plugin in GitHub](https://github.com/pkp/paperbuzz)
 
-## Paypal Fee Payment	
-Supports the processing of payments the PayPal service. Payment types include author processing charges (single fee), reader fees (articles and issues), general fees. 
-* [Paypal plugin in guide](https://docs.pkp.sfu.ca/using-paypal-for-ojs-and-ocs/en/)
-* [Paypal plugin in guide](https://docs.pkp.sfu.ca/learning-ojs/en/subscriptions#payments")
+## PayPal Fee Payment
 
-## PDF.JS PDF Viewer			
+Supports the processing of payments the PayPal service. Payment types include author processing charges (single fee), reader fees (articles and issues), general fees.
+
+* [PayPal plugin in guide](/using-paypal-for-ojs-and-ocs/en/)
+* [PayPal plugin in guide](/learning-ojs/en/subscriptions#payments")
+
+## PDF.JS PDF Viewer
+
 Provides browser-based viewer for article and issue galleys in PDF.
 
-## PKP Usage Statistics Report	
+## PKP Usage Statistics Report
+
 Generates a CSV spreadsheet containing monthly views for the journal homepage; issue TOCs; article abstract/landing pages; and file downloads. It can provides country information (if configured).
-* [Usage Statistics Report plugin in guide](https://docs.pkp.sfu.ca/learning-ojs/en/statistics#usage-statistics-report)
 
-## PKP|PN	
-Enables the automatic preservation of published journal content in the <a href="https://pkp.sfu.ca/pkp-pn/">PKP Preservation Network</a> (PKP|PN).Note: This plugin requires ZipArchive support. See <a href="https://www.php.net/manual/en/zip.installation.php">https://www.php.net/manual/en/zip.installation.php</a> for details.
-* [PKP PN plugin in guide](https://docs.pkp.sfu.ca/pkp-pn/en/)
-* [PKP PN plugin in Github](https://github.com/pkp/pln)
+* [Usage Statistics Report plugin in guide](/learning-ojs/en/statistics#usage-statistics-report)
 
-## Plugins update notification	
+## PKP|PN
+
+Enables the automatic preservation of published journal content in the [PKP Preservation Network](https://pkp.sfu.ca/pkp-pn/) (PKP|PN). This plugin requires [ZipArchive](https://www.php.net/manual/en/zip.installation.php) support.
+
+* [PKP PN plugin in guide](/pkp-pn/en/)
+* [PKP PN plugin in GitHub](https://github.com/pkp/pln)
+
+## Plugins update notification
+
 Generates a notification in the Website Settings  informing which plugins have an upgrade available at the plugin gallery.
-* [Plugin update notification plugin in Github](https://github.com/lepidus/pluginUpdateNotification)
 
-## Plum Analytics		
+* [Plugin update notification plugin in GitHub](https://github.com/lepidus/pluginUpdateNotification)
+
+## Plum Analytics
+
 Provides display of PlumX Metrics from Plum Analytics on the article level for PKP Open Journal Systems.
-* [Plum Analytics plugin in Github](https://github.com/ulsdevteam/ojs-plum-plugin)
 
-## Portico 
-Provides an import/export plugin to generate metadata information for articles and issues for indexing in Portico FTP deposit. Details on the XML format and data requirements is available at: https://www.portico.org. This plugin requires <a href="https://www.php.net/manual/en/zip.installation.php">ZipArchive</a> support.
-* [Portico plugin in Github](	https://github.com/pkp/portico)
+* [Plum Analytics plugin in GitHub](https://github.com/ulsdevteam/ojs-plum-plugin)
 
-## Pragma Theme	
+## Portico
+
+Provides an import/export plugin to generate metadata information for articles and issues for indexing in Portico FTP deposit. Details on the XML format and data requirements is available at: [https://www.portico.org](https://www.portico.org). This plugin requires [ZipArchive](https://www.php.net/manual/en/zip.installation.php) support.
+
+* [Portico plugin in GitHub](https://github.com/pkp/portico)
+
+## Pragma Theme
+
 An official theme for OJS 3 that applies a minimalist OJS theme inspired by early periodicals’ tables of contents featuring a bold use of a monochromatic colour palette.
-* [Pragma Theme plugin in Github](https://github.com/pkp/pragma)
 
-##  Public Identifier Resolver		
+* [Pragma Theme plugin in GitHub](https://github.com/pkp/pragma)
+
+## Public Identifier Resolver
+
 Resolves individual articles, issues and galleys in the current OJS installation using the supplied public identifier register in OJS. It can obtain the element metadata using the format ERC adding question marks at the end of the persistent identifier. ERC format includes the metadata who, what, when, where, how and target.
+
 * [Public Identifier Resolver plugin](https://github.com/yasielpv/pubIdResolver)
 
-## Publons Reviewer Recognition 	
-Enables integration with Publons Reviewer Recognition Service. This plugin will require the [Reviewer Recognition Service](https://publons.com/benefits/publishers) to account to be set up. 
-* [Publons Reviewer Recognition plugin in Github](https://github.com/publons/ojs_3_plugin/)
+## Publons Reviewer Recognition
 
-## PubMed XML Export 
-Export article metadata in PubMed XML format for journals indexed in MEDLINE. 
-* [PubMed XML Export plugin in guide](https://docs.pkp.sfu.ca/admin-guide/en/data-import-and-export#pubmed-xml-export-plugin)
+Enables integration with Publons Reviewer Recognition Service. This plugin will require the [Reviewer Recognition Service](https://publons.com/benefits/publishers) to account to be set up.
 
-## PURL		
-Enables the assignation and management of persistent uniform resource locator (PURL) ID to issue, article and galley. 
-* [PURL plugin in Github](https://github.com/yasielpv/pkp-purl-pubid)
+* [Publons Reviewer Recognition plugin in GitHub](https://github.com/publons/ojs_3_plugin/)
 
-## QuickSubmit 
-Permits Journal Managers/Editors to quickly enter submissions through the OJS website, bypassing the editorial workflow. 
-* [QuickSubmit plugin in guide](https://docs.pkp.sfu.ca/learning-ojs/en/tools#quick-submit-plugin)
-* [QuickSubmit plugin in Github](https://github.com/pkp/quickSubmit)
+## PubMed XML Export
 
-## Recommend Articles by Author	
-Inserts a list of articles by the same author on the article abstract/landing page. 
-* [Recommended Articles plugin in guide](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#recommend-articles-by-author-plugin)
+Export article metadata in PubMed XML format for journals indexed in MEDLINE.
 
-## Recommend Similar Articles	
+* [PubMed XML Export plugin in guide](/admin-guide/en/data-import-and-export#pubmed-xml-export-plugin)
+
+## PURL
+
+Enables the assignation and management of persistent uniform resource locator (PURL) ID to issue, article and galley.
+
+* [PURL plugin in GitHub](https://github.com/yasielpv/pkp-purl-pubid)
+
+## QuickSubmit
+
+Permits Journal Managers/Editors to quickly enter submissions through the OJS website, bypassing the editorial workflow.
+
+* [QuickSubmit plugin in guide](/learning-ojs/en/tools#quick-submit-plugin)
+* [QuickSubmit plugin in GitHub](https://github.com/pkp/quickSubmit)
+
+## Recommend Articles by Author
+
+Inserts a list of articles by the same author on the article abstract/landing page.
+
+* [Recommended Articles plugin in guide](/learning-ojs/en/settings-website#recommend-articles-by-author-plugin)
+
+## Recommend Similar Articles
+
 Adds a list of similar articles to the bottom of the articles abstract/landing page.
-* [Recommended Similar Articles plugin in guide](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#recommend-similar-articles-plugin) 
 
-## Registration Notification			
+* [Recommended Similar Articles plugin in guide](/learning-ojs/en/settings-website#recommend-similar-articles-plugin) 
+
+## Registration Notification
+
 Sends an email notification to a configurable list of emails, configurable per journal/press, whenever a new user is registered. The email content is configurable through the email template named Registration Notification. The following variables are provided by the plugin: $date, $userFullName, $userName, $userEmail
-* [Registration Notification plugin in Github](https://github.com/pkp/registrationNotification)
 
-## Research Organization Registry(ROR) 
-Integrates support for <a href="https://ror.org/">ROR</a>. Organizations maintained by ROR.org are automatically fetched using an auto suggesting function. For multilingual journals, additionally supported languages will be pre-filled given, ROR.org has the corresponding names in the OJS supported languages.
-* [ROR plugin in Github](	https://github.com/withanage/ror/)
+* [Registration Notification plugin in GitHub](https://github.com/pkp/registrationNotification)
 
-## Returning Author Screening 		
+## Research Organization Registry(ROR)
+
+Integrates support for [ROR](https://ror.org/). Organizations maintained by ROR.org are automatically fetched using an auto suggesting function. For multilingual journals, additionally supported languages will be pre-filled given, ROR.org has the corresponding names in the OJS supported languages.
+
+* [ROR plugin in GitHub](https://github.com/withanage/ror/)
+
+## Returning Author Screening
+
 Permits authors using who already have at least one published submission to self-publish subsequent submissions on OPS.
-* [Returning Author Screening pluguin in Github](https://github.com/pkp/returningAuthorScreening)
 
-## ReviewerCredits		
+* [Returning Author Screening plugin in GitHub](https://github.com/pkp/returningAuthorScreening)
+
+## ReviewerCredits
+
 Enables integration with ReviewerCredits. ReviewerCredits Journal credentials will be required to configure the plugin.
-* [ReviewerCredits plugin in Github](https://gitlab.com/reviewercredits/reviewercredits-ojs-plugin)
 
-## RFC1807 Metadata Format			
+* [ReviewerCredits plugin in GitHub](https://gitlab.com/reviewercredits/reviewercredits-ojs-plugin)
+
+## RFC1807 Metadata Format
+
 Structures metadata in a way that is consistent with the RFC1807 format.
 
-## SciELO Submissions Report		
-Generates a CSV spreadsheet with submissions information for OJS and OPS that is usually requested by SciELO
-* [SciELO Submissions Report plugin in Github](https://github.com/lepidus/scieloSubmissionsReport)
+## SciELO Submissions Report
 
-## Scopus/Crossref Citations		
+Generates a CSV spreadsheet with submissions information for OJS and OPS that is usually requested by SciELO.
+
+* [SciELO Submissions Report plugin in GitHub](https://github.com/lepidus/scieloSubmissionsReport)
+
+## Scopus/Crossref Citations
+
 Uses an articles DOI to get all citations from Scopus and/or Crossref. Google Scholar and PubMed are also supported. The count and list of citations is displayed in the sidebar of the article details. It is possible to choose between the different providers and display only the amount of results if the list is not desired.
-* [Scopus/Crossref Citations plugin in Github](https://github.com/RBoelter/citations)
 
-## Shariff 	
-Adds social media buttons to your web site (to the footer of each page or the sidebar) without compromising the privacy of website users. 
-* [Shariff Plugin in Github] (https://github.com/ojsde/shariff)
+* [Scopus/Crossref Citations plugin in GitHub](https://github.com/RBoelter/citations)
 
-## Shibboleth	
-Adds an ability to use shibboleth single sign-on service to register and authenticate users. You must have set up and configured the local service provider (SP). 
-* [Shibboleth plugin in guide](https://docs.pkp.sfu.ca/admin-guide/en/single-signon#setting-up-shibboleth)
-* [Shibboleth plugin in Github](	https://github.com/pkp/shibboleth)
+## Shariff
 
-## Sitesearch		
+Adds social media buttons to your web site (to the footer of each page or the sidebar) without compromising the privacy of website users.
+
+* [Shariff Plugin in GitHub](https://github.com/ojsde/shariff)
+
+## Shibboleth
+
+Adds an ability to use shibboleth single sign-on service to register and authenticate users. You must have set up and configured the local service provider (SP).
+
+* [Shibboleth plugin in guide](/admin-guide/en/single-signon#setting-up-shibboleth)
+* [Shibboleth plugin in GitHub](https://github.com/pkp/shibboleth)
+
+## Sitesearch
+
 Allows searches done in one journal (within a multi-journal installation) to be performed at the site level and returns results from all journals.
-* [Sitesearch plugin in Github](https://github.com/ulsdevteam/pkp-sitesearch)
 
-## Subscription Block	
+* [Sitesearch plugin in GitHub](https://github.com/ulsdevteam/pkp-sitesearch)
+
+## Subscription Block
+
 Provides sidebar subscription information in journals with enabled subscriptions.
-* [Subscription Block plugin in guide](https://docs.pkp.sfu.ca/learning-ojs/en/subscriptions#subscription-block)
 
-## Subscription SSO	
+* [Subscription Block plugin in guide](/learning-ojs/en/subscriptions#subscription-block)
+
+## Subscription SSO
+
 Permits delegation of OJS subscription checks to a third-party web service.
-* [Subscription SSO plugin in Github](https://github.com/asmecher/subscriptionSSO)
 
-## Subscriptions Report	
+* [Subscription SSO plugin in GitHub](https://github.com/asmecher/subscriptionSSO)
+
+## Subscriptions Report
+
 Generates a CSV spreadsheet containing a list of subscriptions and their information. This report provides subscription status, type, format, dates, and subscriber information.
-* [Subscription Report plugin in guide](https://docs.pkp.sfu.ca/learning-ojs/en/statistics#usage-statistics-report)
 
-## Suggested Reviewers Plugin by Ubiquity Press (unvetted)		
-Allows journals to enable Recommended and Excuded Reviewers into the Author Submission form. This information will be displayed on top of the reviewer list when Editors select reviewers for a manuscript.
+* [Subscription Report plugin in guide](/learning-ojs/en/statistics#usage-statistics-report)
+
+## Suggested Reviewers Plugin by Ubiquity Press (unvetted)
+
+Allows journals to enable Recommended and Excluded Reviewers into the Author Submission form. This information will be displayed on top of the reviewer list when Editors select reviewers for a manuscript.
+
 * [Suggested Reviewers Plugin in Gitlab](https://gitlab.com/ubiquitypress/ojs-plugin-suggested-reviewers)
 
-## SushiLite		
+## SushiLite
+
 Provides the NISO SUSHI-Lite standard (2015 draft release) for PKP software.
-* [SushiLite plugin in Github](https://github.com/ulsdevteam/ojs-sushiLite-plugin)
 
-## SWORD Deposit 	
+* [SushiLite plugin in GitHub](https://github.com/ulsdevteam/ojs-sushiLite-plugin)
+
+## SWORD Deposit
+
 Permits the use of the SWORD protocol to deposit documents from OJS into other systems.
-* [Sword plugin in Github](https://github.com/asmecher/sword/)
 
-## Sword Server 		
-Permits the use of the <a href="http://swordapp.org/sword-v2/">SWORDv2 protocol</a> to allow OJS to receive deposit documents from other systems.
-* [Sword Server plugin in Github](https://github.com/quoideneuf/swordServer)
+* [Sword plugin in GitHub](https://github.com/asmecher/sword/)
 
-## Text Editor Extras		
+## Sword Server
+
+Permits the use of the [SWORDv2 protocol](http://swordapp.org/sword-v2/) to allow OJS to receive deposit documents from other systems.
+
+* [Sword Server plugin in GitHub](https://github.com/quoideneuf/swordServer)
+
+## Text Editor Extras
+
 Provides additional rich text editor control (upload images, manipulate the HTML code, and add tables) to various text fields.
-* [Text Editors Extras plugin in Github](https://github.com/pkp/textEditorExtras)
 
-## Texture 	
+* [Text Editors Extras plugin in GitHub](https://github.com/pkp/textEditorExtras)
+
+## Texture
+
 Integrates the Texture JATS XML editor with OJS.
-* [Texture plugin in Github](https://github.com/pkp/texture)
 
-## TinyMCE 		
-Converts select textareas to WYSIWYG XHTML editors using the TinyMCE cross-browser Javascript editor.  This allows authors, editors, etc. to easily enter valid HTML into the various forms for
-more control over the appearance of their content."
+* [Texture plugin in GitHub](https://github.com/pkp/texture)
 
-## Title Page (unvetted)	
+## TinyMCE
+
+Converts select textareas to WYSIWYG XHTML editors using the TinyMCE cross-browser Javascript editor. This allows authors, editors, etc. to easily enter valid HTML into the various forms for more control over the appearance of their content.
+
+## Title Page (unvetted)
+
 OPS plugin that creates a title page on PDF files submitted to preprint servers. The title page is a page added to the beginning of the PDF file, containing a series of information about the preprint when it is posted. After the preprint is posted, the title page is also updated if the preprint relations are changed.
-* [Title Page Plugin in Github](https://github.com/lepidus/titlePageForPreprint)
 
-## Twitter Block 
+* [Title Page Plugin in GitHub](https://github.com/lepidus/titlePageForPreprint)
+
+## Twitter Block
+
 Integrates Twitter feeds in a multi-journal instance without the need to create several custom blocks. This plugin requires Administrator access to configure and enable/disable.
 
-## URN			
+## URN
+
 Enables the assignment of the Uniform Resource Names to the issues, articles and galleys.
 
-## Usage Statistics	
+## Usage Statistics
+
 Displays the number of article downloads on the article page, in bar or line graph format. Requires Administrator access to be enabled or disabled.
-* [Usage Statistics plugin in guide](https://docs.pkp.sfu.ca/learning-ojs/en/settings-website#usage-statistics-plugin)
 
-## Users XML 
+* [Usage Statistics plugin in guide](/learning-ojs/en/settings-website#usage-statistics-plugin)
+
+## Users XML
+
 Allows import and export of users and their roles between the same OJS versions.
-* [Users XML plugin in guide](https://docs.pkp.sfu.ca/admin-guide/en/data-import-and-export#export-users-to-xml)
 
-## View Report 	
-Generates a CSV spreadsheet describing readership for each articlem,, including article title, issue, date published, and view counts (for abstracts, individual galleys, total galleys).
-* [View Report in guide](https://docs.pkp.sfu.ca/learning-ojs/en/statistics#view-report	)
+* [Users XML plugin in guide](/admin-guide/en/data-import-and-export#export-users-to-xml)
 
-## Web Feed Plugin			
+## View Report
+
+Generates a CSV spreadsheet describing readership for each article, including article title, issue, date published, and view counts (for abstracts, individual galleys, total galleys).
+
+* [View Report in guide](/learning-ojs/en/statistics#view-report)
+
+## Web Feed Plugin
+
 Produces RSS/Atom web syndication feeds for the current issue.

--- a/plugin-inventory/en/inventory.md
+++ b/plugin-inventory/en/inventory.md
@@ -1,0 +1,5 @@
+---
+title: "Plugin Inventory"
+---
+
+# Plugin Inventory

--- a/plugin-inventory/index.md
+++ b/plugin-inventory/index.md
@@ -1,0 +1,9 @@
+---
+isBookIndex: true
+---
+
+# Plugin Inventory
+
+* [English](./en)
+
+The plugin inventory brings together links to existing plugin documentation for OJS/OMP/OPS. This list is not exhaustive and will continue to be updated as more plugin guides become available.


### PR DESCRIPTION
Adds the new plugin inventory and links it in the "plugin" cards on the home page under OJS/OMP/OPS.