### PR TITLE
Added note about deleting submissions

### DIFF
--- a/faq/en/editorial-workflow.md
+++ b/faq/en/editorial-workflow.md
@@ -87,7 +87,9 @@ See also [this forum article](http://forum.pkp.sfu.ca/t/error-message-on-upload-
 
 ## How do I delete an article from OJS?
 
-As of OJS 3.3, articles must first be declined before they can be deleted. Depending on the workflow stage that the submission is in, a Journal Editor or Journal Manager may need to return to an earlier stage (such as Submission) and select "Change decision." Once the submission is declined, follow the steps below to delete the submission.
+As of OJS 3.3, articles must first be declined before they can be deleted. Incomplete submissions must also be completed before they be declined. You may need to enter temporary / filler metadata and upload a sample file to complete a submission so that it can be declined and deleted.
+
+Depending on the workflow stage that the submission is in, a Journal Editor or Journal Manager may need to return to an earlier stage (such as Submission) and select "Change decision." Once the submission is declined, follow the steps below to delete the submission.
 
 - Login as the Journal Editor or Journal Manager
 - Find the article record on the submissions page


### PR DESCRIPTION
Incomplete submissions must be completed before they can be declined and deleted - added this to the "How do I delete an article" section.