### PR TITLE
Document new default galley styles feature

### DIFF
--- a/pkp-theming-guide/en/theme-api.md
+++ b/pkp-theming-guide/en/theme-api.md
@@ -72,12 +72,12 @@ Styles with the `frontend` context will be output in your theme where you place 
 
 You can define and use multiple contexts if you'd like. But `frontend` is the standard for themes and will be set automatically if no `context` argument is passed.
 
-Use the `htmlGalley` context to add default styling for html galleys. 
+Use the htmlGalley context to add a stylesheet to HTML galleys.
 
 ```php
 $this->addStyle('htmlGalley', 'path/to/galley.css', ['contexts' => 'htmlGalley']);
 ```
-Styles with the `htmlGalley` context will be included in html galleys by injecting a `<link>` tag with specified css into `<head>` tag of the html galley.
+A stylesheet assigned to the `htmlGalley` context will be loaded when a HTML galley is displayed. A `<link>` tag will be injected into the `<head>` of the galley's HTML file.
 
 ## modifyStyle\(\)
 

--- a/pkp-theming-guide/en/theme-api.md
+++ b/pkp-theming-guide/en/theme-api.md
@@ -52,7 +52,7 @@ This method accepts a number of optional `$args`.
  *   theme directory or, if the `inline` argument is included, style data to
  *   be output.
  * @param $args array Optional arguments hash. Supported args:
- *   'context': Whether to load this on the `frontend` or `backend`.
+ *   'context': Whether to load this on the `frontend`, `backend`, or `htmlGalley`.
  *      default: `frontend`
  *   'priority': Controls order in which styles are printed
  *   'addLess': Additional LESS files to process before compiling. Array
@@ -71,6 +71,13 @@ Styles with the `frontend` context will be output in your theme where you place 
 ```
 
 You can define and use multiple contexts if you'd like. But `frontend` is the standard for themes and will be set automatically if no `context` argument is passed.
+
+Use the `htmlGalley` context to add default styling for html galleys. 
+
+```php
+$this->addStyle('htmlGalley', 'path/to/galley.css', ['contexts' => 'htmlGalley']);
+```
+Styles with the `htmlGalley` context will be included in html galleys by injecting a `<link>` tag with specified css into `<head>` tag of the html galley.
 
 ## modifyStyle\(\)
 


### PR DESCRIPTION
Resolves https://github.com/pkp/pkp-docs/issues/156

Add documentation about default galley styles feature with code snippet example on using new `htmlGalley` context argument in `addStyle` function.

We may want to add this new context option to the inline documentation in the theme source code.