### PR TITLE
Prototype of page-based table of contents for every page

### DIFF
--- a/_includes/anchor_headings.html
+++ b/_includes/anchor_headings.html
@@ -82,19 +82,25 @@
       {% else %}
         {% capture anchor %} {{ anchor }}{% endcapture %}
       {% endif %}
-    {% endif %}
 
-    {% capture new_heading %}
-      <h{{ _hAttrToStrip }}
-        {{ include.bodyPrefix }}
-        {% if beforeHeading %}
-          {{ anchor }}{{ header }}
-        {% else %}
-          {{ header }}{{ anchor }}
-        {% endif %}
-        {{ include.bodySuffix }}
-      </h{{ _workspace | last }}
-    {% endcapture %}
+      {% capture new_heading %}
+        <h{{ _hAttrToStrip }}
+          {{ include.bodyPrefix }}
+          {% if beforeHeading %}
+            {{ anchor }}{{ header }}
+          {% else %}
+            {{ header }}{{ anchor }}
+          {% endif %}
+          {{ include.bodySuffix }}
+        </h{{ _workspace | last }}
+      {% endcapture %}
+
+    {% else %}
+      {% capture new_heading %}
+        <h1>{{ header }}</h1>
+        {% include book/toc.html html=content h_min=2 h_max=3 %}
+      {% endcapture %}
+    {% endif %}
     {% capture edited_headings %}{{ edited_headings }}{{ new_heading }}{% endcapture %}
   {% endfor %}
 {% endcapture %}{% assign headingsWorkspace = '' %}{{ edited_headings | strip }}

--- a/_includes/anchor_headings.html
+++ b/_includes/anchor_headings.html
@@ -83,24 +83,35 @@
         {% capture anchor %} {{ anchor }}{% endcapture %}
       {% endif %}
 
-      {% capture new_heading %}
-        <h{{ _hAttrToStrip }}
-          {{ include.bodyPrefix }}
-          {% if beforeHeading %}
-            {{ anchor }}{{ header }}
-          {% else %}
-            {{ header }}{{ anchor }}
-          {% endif %}
-          {{ include.bodySuffix }}
-        </h{{ _workspace | last }}
-      {% endcapture %}
-
-    {% else %}
-      {% capture new_heading %}
-        <h1>{{ header }}</h1>
-        {% include book/toc.html html=content h_min=2 h_max=3 %}
-      {% endcapture %}
     {% endif %}
+
+    {% capture new_heading %}
+        <h{{ _hAttrToStrip }}
+        {{ include.bodyPrefix }}
+        {% if beforeHeading %}
+            {{ anchor }}{{ header }}
+        {% else %}
+            {{ header }}{{ anchor }}
+        {% endif %}
+        {{ include.bodySuffix }}
+        {% if page.showPageTOC and headerLevel == 1 %}
+          </h1>
+          <div class="book__improve">
+              <a href="{{ site.data.site.improveLinkBaseUrl }}{{ page.path }}">
+                  {{ site.data.site.improveLink }}
+              </a>
+              {{ site.data.site.orText }}
+              <a href="{{ site.data.site.contactBaseUrl }}">
+                  {{ site.data.site.contactLink }}
+              </a>
+          </div>
+          {% include book/toc.html html=content h_min=2 h_max=3 %}
+          {% assign _restOfNode = node | split: '</h1>' | last %}
+          {{ _restOfNode }}
+        {% else %}
+          </h{{ _workspace | last }}
+        {% endif %}
+    {% endcapture %}
     {% capture edited_headings %}{{ edited_headings }}{{ new_heading }}{% endcapture %}
   {% endfor %}
 {% endcapture %}{% assign headingsWorkspace = '' %}{{ edited_headings | strip }}

--- a/_includes/anchor_headings.html
+++ b/_includes/anchor_headings.html
@@ -96,15 +96,6 @@
         {{ include.bodySuffix }}
         {% if page.showPageTOC and headerLevel == 1 %}
           </h1>
-          <div class="book__improve">
-              <a href="{{ site.data.site.improveLinkBaseUrl }}{{ page.path }}">
-                  {{ site.data.site.improveLink }}
-              </a>
-              {{ site.data.site.orText }}
-              <a href="{{ site.data.site.contactBaseUrl }}">
-                  {{ site.data.site.contactLink }}
-              </a>
-          </div>
           {% include book/toc.html html=content h_min=2 h_max=3 %}
           {% assign _restOfNode = node | split: '</h1>' | last %}
           {{ _restOfNode }}

--- a/_includes/book/toc.html
+++ b/_includes/book/toc.html
@@ -82,4 +82,18 @@
         {% capture my_toc %}{: #{{ include.id }}}
 {{ my_toc | lstrip }}{% endcapture %}
     {% endif %}
-{% endcapture %}{% assign tocWorkspace = '' %}{{ my_toc | markdownify | strip }}
+{% endcapture %}{% assign tocWorkspace = '' %}
+
+<div class="book_page_toc">
+    <h2>Table of Contents</h2>
+    {{ my_toc | markdownify | strip }}
+    <div class="book__improve">
+        <a href="{{ site.data.site.improveLinkBaseUrl }}{{ page.path }}">
+            {{ site.data.site.improveLink }}
+        </a>
+        {{ site.data.site.orText }}
+        <a href="{{ site.data.site.contactBaseUrl }}">
+            {{ site.data.site.contactLink }}
+        </a>
+    </div>
+</div>

--- a/_includes/book/toc.html
+++ b/_includes/book/toc.html
@@ -87,13 +87,4 @@
 <div class="book_page_toc">
     <h2>Table of Contents</h2>
     {{ my_toc | markdownify | strip }}
-    <div class="book__improve">
-        <a href="{{ site.data.site.improveLinkBaseUrl }}{{ page.path }}">
-            {{ site.data.site.improveLink }}
-        </a>
-        {{ site.data.site.orText }}
-        <a href="{{ site.data.site.contactBaseUrl }}">
-            {{ site.data.site.contactLink }}
-        </a>
-    </div>
 </div>

--- a/_includes/cards/dev/contributors.md
+++ b/_includes/cards/dev/contributors.md
@@ -1,4 +1,4 @@
 
-### [Contributor's Guide](./contributors)
+### [Contributor's Guide](./contributors/en)
 
-Learn how to contribute to Open Journal Systems, Open Monograph Press, and Open Preprint Systems. [View Now](./contributors)
+Learn how to contribute to Open Journal Systems, Open Monograph Press, and Open Preprint Systems. [View Now](./contributors/en)

--- a/_includes/cards/dev/contributors.md
+++ b/_includes/cards/dev/contributors.md
@@ -1,4 +1,4 @@
 
-### [Contributor's Guide](./contributors/en)
+### [Contributor's Guide](./contributors)
 
-Learn how to contribute to Open Journal Systems, Open Monograph Press, and Open Preprint Systems. [View Now](./contributors/en)
+Learn how to contribute to Open Journal Systems, Open Monograph Press, and Open Preprint Systems. [View Now](./contributors)

--- a/_includes/cards/ojs3/developer-docs.md
+++ b/_includes/cards/ojs3/developer-docs.md
@@ -6,8 +6,8 @@ Guides to host and deploy OJS, write themes and plugins, and contribute new feat
 ---
 
 - [Administrator's Guide](/admin-guide/)
-- [How to Upgrade](/dev/upgrade-guide/)
-- [Main Documentation](/dev/documentation/)
+- [How to Upgrade](/dev/upgrade-guide/en/)
+- [Main Documentation](/dev/documentation/en/)
 - [Theming Guide](/pkp-theming-guide/)
-- [Plugin Guide](/dev/plugin-guide/)
+- [Plugin Guide](/dev/plugin-guide/en/)
 - ... and [more](/dev/)

--- a/_layouts/book.html
+++ b/_layouts/book.html
@@ -11,16 +11,7 @@
 			{% endif %}
 			<div class="book__page">
 				<div class="book__content">
-					<div class="book__improve">
-						<a href="{{ site.data.site.improveLinkBaseUrl }}{{ page.path }}">
-							{{ site.data.site.improveLink }}
-						</a>
-						{{ site.data.site.orText }}
-						<a href="{{ site.data.site.contactBaseUrl }}">
-							{{ site.data.site.contactLink }}
-						</a>
-					</div>
-					{% include anchor_headings.html html=content anchorBody='#' anchorTitle='Link to %heading% section' h_min=2 %}
+					{% include anchor_headings.html html=content anchorBody='#' anchorTitle='Link to %heading% section' anchorClass="book_heading_anchor" h_min=2 %}
 					{% unless page.isBookIndex %}
 						{% if page.name == "index.md" or page.name == "README.md"  %}
 							{% include book/copyright.html %}

--- a/_layouts/book.html
+++ b/_layouts/book.html
@@ -11,6 +11,15 @@
 			{% endif %}
 			<div class="book__page">
 				<div class="book__content">
+					<div class="book__improve">
+						<a href="{{ site.data.site.improveLinkBaseUrl }}{{ page.path }}">
+							{{ site.data.site.improveLink }}
+						</a>
+						{{ site.data.site.orText }}
+						<a href="{{ site.data.site.contactBaseUrl }}">
+							{{ site.data.site.contactLink }}
+						</a>
+					</div>
 					{% include anchor_headings.html html=content anchorBody='#' anchorTitle='Link to %heading% section' anchorClass="book_heading_anchor" h_min=2 %}
 					{% unless page.isBookIndex %}
 						{% if page.name == "index.md" or page.name == "README.md"  %}

--- a/_sass/components/book.scss
+++ b/_sass/components/book.scss
@@ -169,6 +169,10 @@
 	}
 }
 
+.book__improve {
+	margin-bottom: 2rem;
+}
+
 .book_page_toc {
 
 	h2 {

--- a/_sass/components/book.scss
+++ b/_sass/components/book.scss
@@ -38,7 +38,7 @@
 		th {
 			font-weight: $bold;
 		}
-		
+
 		a {
 			word-break: unset;
 		}
@@ -321,6 +321,20 @@
 		// Make sure the footer is pushed to the bottom of the screen
 		// even if the book content is very short
 		min-height: calc(100vh - 30rem);
+
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6 {
+			position: relative;
+		}
+	}
+
+	.book_heading_anchor {
+		position: absolute;
+		left: -2rem;
 	}
 
 	.book__footerWrapper {

--- a/_sass/components/book.scss
+++ b/_sass/components/book.scss
@@ -169,13 +169,19 @@
 	}
 }
 
-.book__improve {
-	display: inline-block;
-	margin-bottom: 2em;
-}
+.book_page_toc {
 
-.book__footer .book__improve {
-	margin-top: 3rem;
+	h2 {
+		font-size: 1rem;
+		margin: 1rem 0 0.5rem;
+		border-bottom: 1px solid #ddd;
+		padding: 0 0 0.5rem;
+	}
+
+	> ul {
+		margin-top: 0;
+		padding-left: 1rem;
+	}
 }
 
 .book__sidebar {
@@ -283,19 +289,6 @@
 		display: inline-block;
 		margin: 0;
 		margin-left: 0.75em;
-	}
-}
-
-@media (min-width: 480px) {
-
-	.book__improve {
-		float: right;
-		margin-left: 2em;
-	}
-
-	.book__footer .book__improve {
-		float: none;
-		margin-left: 0;
 	}
 }
 

--- a/learning-ojs/en/about-ojs.md
+++ b/learning-ojs/en/about-ojs.md
@@ -2,6 +2,7 @@
 book: learning-ojs
 showPageTOC: true
 version: 3.3
+showPageTOC: true
 ---
 
 # About Open Journal Systems (OJS)


### PR DESCRIPTION
One of the recommendations from the docs hub focus group was to include a table of contents for each page, in addition to the book-wide table of contents on the left. This PR implements a quick prototype of that for discussion.

A challenge is figuring out how to present this second table of contents on the page. Many other sites include this second table of contents on the right, inline with the main document text. Here is an example.

![toc-floated-full](https://user-images.githubusercontent.com/2306629/188425845-51f0d3a2-5c42-4568-9589-fa0c93e93df0.png)

However, this presents some problems when the document includes a video, image or code snippet high enough up the page that the table of contents pushes it down.

![toc-floated](https://user-images.githubusercontent.com/2306629/188425990-bd846dcb-78d8-4094-8abb-8ea1e41d4473.png)

One way to work around this is to make the TOC inline directly below the heading, but I worry it isn't immediately clear that we're looking at a table of contents.

![toc-inline](https://user-images.githubusercontent.com/2306629/188426130-95ed2808-2e6e-4b66-8e98-990031f2ff8d.png)