### PR TITLE
Updated chapter headings in Plan S guide

### DIFF
--- a/plan-s/en/index.md
+++ b/plan-s/en/index.md
@@ -31,7 +31,7 @@ This guide is intended for journals published on OJS which intend to meet the Re
 
 While we will do our best to keep this guide up-to-date, the Plan S documentation should be relied upon for the most current and detailed information.
 
-## 1.1 Basic mandatory conditions for all publication venues
+## Basic mandatory conditions for all publication venues
 
 ### Review policies
 
@@ -258,7 +258,7 @@ Plan S recommends that journals provide open citation data in a way that is shar
 
 2. Submit your references to Crossref. In OJS, this can be done by using the [Crossref Reference Linking plugin](https://docs.pkp.sfu.ca/crossref-ojs-manual/en/references). The plugin will deposit references to Crossref and return DOIs to include in article references in OJS. There is no additional charge to Crossref members for using the plugin.
 
-## 1.2 Specific conditions for Open Access journals 
+## Specific conditions for Open Access journals 
 
 ### DOAJ registration
 


### PR DESCRIPTION
Removed the numbers referring to Plan S sections from the chapter headings, per a suggestion from @marcbria.