### PR TITLE
Update ORCID Plugin Guide README

### DIFF
--- a/orcid/en/README.md
+++ b/orcid/en/README.md
@@ -13,6 +13,6 @@ This video is for OJS administrators at ORCID member institutions, such as acade
 
 ## Software compatibility
 
-The ORCID Profile Plugin is supported in OJS 3.1.2 and above and OPS 3.1.2 and above. Previous versions of the ORCID Profile Plugin vary in functionality. Both OJS and OPS share the same basic platform and therefore the instructions presented in this document apply for both journals using OJS and preprint servers using OPS.
+The ORCID Profile Plugin is available for OJS 3.1.2 and above and OPS 3.1.2 and above. Previous versions of the ORCID Profile Plugin have limited functionality. Both OJS and OPS share the same basic platform and therefore the instructions presented in this document apply for both journals using OJS and preprint servers using OPS.
 
 The ORCID plugin is not currently available in [Open Monograph Press (OMP)](https://pkp.sfu.ca/omp/). Users of OMP can manually enter their ORCID iD in their user profile under View Profile > Public, but metadata will not be automatically sent from OMP to ORCID, unlike OJS/OPS where metadata can be exchanged if the plugin is configured correctly.


### PR DESCRIPTION
Clarified that the plugin is compatible with certain versions of OJS and OPS rather than "supported" for certain versions.