### PR TITLE
Fix frontend/ListPanels HTML title

### DIFF
--- a/dev/documentation/en/frontend-list-panels.md
+++ b/dev/documentation/en/frontend-list-panels.md
@@ -1,7 +1,7 @@
 ---
 book: dev-documentation
 version: 3.4
-title: Forms - Frontend - Technical Documentation - OJS|OMP|OPS
+title: List Panels - Frontend - Technical Documentation - OJS|OMP|OPS
 ---
 
 # List Panels


### PR DESCRIPTION
Probably was a copy and paste issue that set title as Form.

I did not opened a Issue since is a hot fix.

It took me 5min to find the List Panels tab among all the PKP/docs tabs I had opened haha