### PR TITLE
Hook list updates from PKP sprint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,5 @@ group :jekyll_plugins do
 	gem 'jekyll-readme-index'
 	gem 'jekyll-sitemap'
 end
+
+gem "webrick", "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.8.0)
+    webrick (1.8.1)
 
 PLATFORMS
   ruby
@@ -80,6 +81,7 @@ DEPENDENCIES
   jekyll-seo-tag
   jekyll-sitemap
   jekyll-titles-from-headings
+  webrick (~> 1.8)
 
 BUNDLED WITH
-   2.1.4
+   2.5.10

--- a/dev/documentation/3.3/en/utilities-hooks.md
+++ b/dev/documentation/3.3/en/utilities-hooks.md
@@ -1,6 +1,7 @@
 ---
 book: dev-documentation
 version: 3.3
+showPageTOC: true
 title: Hooks - Technical Documentation - OJS|OMP|OPS 3.3
 ---
 
@@ -102,7 +103,7 @@ Hooks are most commonly used in generic plugins. Calling hooks from other types 
 
 The following is a list of the most common hooks that can be used.
 
-> This is an incomplete list. Search the application code for `HookRegistry::call` to get a complete list.
+> This is an incomplete list. Search the [application code](https://github.com/pkp/ojs/tree/stable-3_3_0) for `HookRegistry::call` to get a complete list of hooks available in OJS 3.3.
 {:.warning}
 
 ### Request, Routing and Templating

--- a/dev/documentation/en/utilities-hooks.md
+++ b/dev/documentation/en/utilities-hooks.md
@@ -1,6 +1,7 @@
 ---
 book: dev-documentation
 version: 3.4
+showPageTOC: true
 title: Hooks - Technical Documentation - OJS|OMP|OPS
 ---
 
@@ -106,7 +107,7 @@ Hooks are most commonly used in generic plugins. Calling hooks from other types 
 
 ## Common Hooks
 
-The following is a list of the most common hooks that can be used. Find all of the hooks in the application by searching for `Hook::call` in the code.
+> This is an incomplete list. Search the [application code](https://github.com/pkp/ojs) for `HookRegistry::call` to get a complete list of hooks available in OJS 3.4.
 {:.warning}
 
 ### Request, Routing and Templating

--- a/ojs-2-technical-reference/en/hook_list.md
+++ b/ojs-2-technical-reference/en/hook_list.md
@@ -1,8 +1,14 @@
 # Hook List
 
+> This hook list is out of date. Some hooks may not work with newer versions of OJS. Please consult [v3.3 Common Hooks](/dev/documentation/3.3/en/utilities-hooks#common-hooks) and [v3.4 Common Hooks](/dev/documentation/en/utilities-hooks#common-hooks) for currently supported hooks. 
+{:.warning}
+
 The following list describes all the hooks built into OJS as of release 2.1. Ampersands before variable names (e.g. ``&$sourceFile``) indicate that the parameter has been passed to the hook callback in the parameters array by reference and can be modified by the hook callback. The effect of the hook callback's return value is specified where applicable; in addition to this, the hook callback return value will always determine whether or not further callbacks registered on the same hook will be skipped.
 
 **Table 5.2. Hook List**
+
+> This hook list is out of date. Some hooks may not work with newer versions of OJS. Please consult [v3.3 Common Hooks](/dev/documentation/3.3/en/utilities-hooks#common-hooks) and [v3.4 Common Hooks](/dev/documentation/en/utilities-hooks#common-hooks) for currently supported hooks. 
+{:.warning}
 
 | Name | Parameters | Description |
 | ----- | ----- | ----- |


### PR DESCRIPTION
The only complete hook list findable from Google is very outdated and lives in the 2.0 Technical Reference. This pull requests adds warning labels to the hook list in the 2.0 Technical References and adds links to the 3.3 and 3.4 codebases so that developers can search for hooks in the appropriate codebases. Once a full hook list is published, links should point to that from every stable version documentation. 

Report of outdated hook list submitted by @trp89. 