### PR TITLE
Fix config path

### DIFF
--- a/dev/upgrade-guide/en/index.md
+++ b/dev/upgrade-guide/en/index.md
@@ -237,7 +237,7 @@ $ cp "$OJS_BACKUP_PATH/html/config.inc.php" "$OJS_WEB_PATH"
 Run the following command to compare your configuration file with the template of the new release. Add or remove any configuration options as necessary.
 
 ```bash
-$ diff "$OJS_BACKUP_PATH/config.inc.php" "$OJS_WEB_PATH/config.TEMPLATE.inc.php"
+$ diff "$OJS_WEB_PATH/config.inc.php" "$OJS_WEB_PATH/config.TEMPLATE.inc.php"
 ```
 
 Restore the `.htaccess` file if it exists.


### PR DESCRIPTION
Pre-upgrade ``config.inc.php`` gets copied to ``$OJS_WEB_PATH`` by the command above this one. ``$OJS_BACKUP_PATH/config.inc.php`` is also invalid, because ``html`` is missing from the path.