### PR TITLE
Clarify paypal for OJS/OMP in 3.3

### DIFF
--- a/dev/documentation/3.3/en/getting-started.md
+++ b/dev/documentation/3.3/en/getting-started.md
@@ -42,6 +42,11 @@ Install dependencies with [composer](https://getcomposer.org/).
 
 ```
 composer --working-dir=lib/pkp install
+```
+
+Run the following command if you are installing OJS or OMP.
+
+```
 composer --working-dir=plugins/paymethod/paypal install
 ```
 


### PR DESCRIPTION
Updates the 3.3 docs to clarify that the paypal composer command is for OJS/OMP, not OPS. This is already corrected in the 3.4 docs.