### PR TITLE
Accessible content guide updates - broken URLs, a11y statement added

### DIFF
--- a/accessible-content/en/introduction.md
+++ b/accessible-content/en/introduction.md
@@ -23,7 +23,7 @@ In this guide we cover the general principles of creating universally accessible
 When it comes to online journals, two aspects of accessibility need to be addressed:
 
 1. **Website or platform accessibility**, i.e. accessibility of OJS itself. This ensures that readers, authors and editors can navigate OJS regardless of any impairments or assistive technologies they use.
-PKP is working on bringing OJS structure and themes up to the current web accessibility standards - for the status of that work or to contribute see this [update on the PKP website](https://pkp.sfu.ca/2020/05/21/is-your-journal-accessible-working-with-community-to-make-ojs-open-for-all/). Additionally, if you modify your journal’s theme yourself, make sure to follow the guidelines outlined in the [Inclusive and Accessible Theming](/designing-your-journal/en/inclusive-and-accessible-theming) chapter of the [Designing Your Journal Guide](/designing-your-journal/).
+The Default Theme in OJS 3.3 and higher has been audited for accessibility barriers and its state of accessibility is outlined in the [OJS 3.3+ Default Theme Accessibility Statement](https://docs.pkp.sfu.ca/accessibility-statement). Additionally, if you modify your journal’s theme yourself, make sure to follow the guidelines outlined in the [Inclusive and Accessible Theming](/designing-your-journal/en/inclusive-and-accessible-theming) chapter of the [Designing Your Journal Guide](/designing-your-journal/).
 
 2. **Content accessibility**, covered in this guide. Specifically, it applies to:
 

--- a/accessible-content/en/principles.md
+++ b/accessible-content/en/principles.md
@@ -87,8 +87,7 @@ When creating video and audio content, it is important to ensure that it is acce
 
     - [YouTube auto captioning for video](https://www.youtube.com/)
     - [Kapwing Caption Video Online](https://www.kapwing.com/tools/caption-video)
-    - [IBM Watson auto captioning for audio](https://speech-to-text-demo.ng.bluemix.net/) (demo)
-
+    
 - **Transcripts**. Transcripts contain the full text of the spoken word (not necessarily verbatim) that could be accessed and read separately from the multimedia itself. Transcripts allow deaf/blind users to get content through the use of refreshable Braille devices. They are also useful for searching and navigating to a specific part of the text.
 
     When planning a video/audio recording, it is a good idea to have the transcript written out ahead of time. It can then be used both for the multimedia creation and to be made available afterwards.
@@ -147,7 +146,7 @@ We often use colour in web content or in published content to convey meaning. Us
 
 ![An orange circle with a word Yes and a green circle with a word No.](./assets/3_a11y-guide-colour-circles-do.png)
 
-Other tools, such as the [Spectrum Chrome extension](https://chrome.google.com/webstore/detail/spectrum/ofclemegkcmilinpcimpjkfhjfgmhieb?hl=en) allow you to emulate different types of CVD on any website. This is particularly useful if your articles contain data visualisations. The following two figures, obtained from an article published in the journal Polar Research, illustrate how CVD can affect a user’s understanding of a graph or a chart.
+Other tools, such as the [Let's Go Color Blind Chrome Extension](https://chromewebstore.google.com/detail/lets-get-color-blind/bkdgdianpkfahpkmphgehigalpighjck) allow you to emulate different types of CVD on any website. This is particularly useful if your articles contain data visualisations. The following two figures, obtained from an article published in the journal Polar Research, illustrate how CVD can affect a user’s understanding of a graph or a chart.
 
 ![Two versions of the same map with different colours, description below.](./assets/4_a11y-guide-colour-chart2.png)
 

--- a/accessible-content/en/resources.md
+++ b/accessible-content/en/resources.md
@@ -34,8 +34,6 @@ A non-extensive list of additional resources on accessible content creation is p
 
 - [Writing for Web Accessibility](https://www.w3.org/WAI/tips/writing/) - Tips on the basic considerations for writing for web accessibility developed by W3C.
 
-- [Creating Accessible Documents in Microsoft Word](https://www.washington.edu/accessibility/documents/word/) - A online guide developed by the University of Washington with information on how to create an accessible document using Microsoft Word.
-
 - [Creating Accessible Documents](https://www.washington.edu/accessibility/documents/) - General information developed by the University of Washington with information on creating accessible documents.
 
 - [Accessibility and Usability at Penn State](https://accessibility.psu.edu/) - An online guide developed by Penn State on how to ensure Web pages and online documents can be made usable for users with different disabilities.

--- a/accessible-content/pt/principles.md
+++ b/accessible-content/pt/principles.md
@@ -87,8 +87,7 @@ Ao criar conteúdo de áudio e vídeo, é fundamental garantir que seja acessív
 
     - [Legenda automática do YouTube para vídeo](https://www.youtube.com/)
     - [Kapwing Caption Video Online](https://www.kapwing.com/tools/caption-video)
-    - [Legendas automáticas Watson da IBM para áudio](https://speech-to-text-demo.ng.bluemix.net/) (demonstração)
-
+  
 - **Transcrições**. A transcrição contém o texto completo das falas (não necessariamente literal) que pode ser acessado e lido separadamente da própria multimídia. Transcrições permitem que pessoas surdas/cegas obtenham conteúdo por meio do uso de dispositivos Braille atualizáveis. Eles também são úteis para pesquisa e navegação para uma seção específica do texto.
 
     Ao planejar uma gravação de áudio/vídeo, é importante escrever a transcrição com antecedência. Ela pode então ser usada tanto para a criação da multimídia quanto para disponibilização posterior.
@@ -147,7 +146,7 @@ Frequentemente, usamos cores em conteúdo da Web ou em conteúdo publicado para 
 
 ![Um círculo laranja com a palavra SIM e um círculo verde com a palavra NÃO.](./assets/3_a11y-guide-colour-circles-do.png)
 
-Outras ferramentas, como a [extensão Spectrum do Chrome](https://chrome.google.com/webstore/detail/spectrum/ofclemegkcmilinpcimpjkfhjfgmhieb?hl=en), permitem emular diferentes tipos de DVC em qualquer site. Isso é particularmente útil se seus artigos contiverem visualizações de dados. As duas figuras a seguir, obtidas de um artigo publicado na revista Polar Research, ilustram como o DVC pode afetar a compreensão de um diagrama ou gráfico pelo leitor.
+Outras ferramentas, como a [extensão Let's Go Color Blind do Chrome](https://chromewebstore.google.com/detail/lets-get-color-blind/bkdgdianpkfahpkmphgehigalpighjck), permitem emular diferentes tipos de DVC em qualquer site. Isso é particularmente útil se seus artigos contiverem visualizações de dados. As duas figuras a seguir, obtidas de um artigo publicado na revista Polar Research, ilustram como o DVC pode afetar a compreensão de um diagrama ou gráfico pelo leitor.
 
 ![Duas versões do mesmo mapa com cores distintas, descrição a seguir.](./assets/4_a11y-guide-colour-chart2.png)
 

--- a/accessible-content/pt/resources.md
+++ b/accessible-content/pt/resources.md
@@ -34,8 +34,6 @@ Apresentamos a seguir uma lista não extensa de recursos adicionais sobre a cria
 
 - [Escrevendo para acessibilidade na web](https://www.w3.org/WAI/tips/writing/) - Dicas sobre as considerações básicas de como escrever para acessibilidade na web desenvolvidas pela W3C.
 
-- [Criando Documentos Acessíveis no Microsoft Word](https://www.washington.edu/accessibility/documents/word/) - Um guia online desenvolvido pela Universidade de Washington com informações sobre como criar um documento acessível usando o Microsoft Word.
-
 - [Criação de documentos acessíveis](https://www.washington.edu/accessibility/documents/) - informações gerais desenvolvidas pela Universidade de Washington com informações sobre a criação de documentos acessíveis.
 
 - [Acessibilidade e usabilidade na Penn State](https://accessibility.psu.edu/) - Um guia online desenvolvido pela Penn State sobre como garantir que páginas da Web e documentos online possam ser disponibilizados para usuários com diferentes deficiências.


### PR DESCRIPTION
Updated the intro with a link to OJS accessibility statement on Docs Hub