### PR TITLE
pkp/pkp-lib#8333 Update route for the site context on the API from "_" to "index"

### DIFF
--- a/dev/api/usage.md
+++ b/dev/api/usage.md
@@ -44,7 +44,7 @@ https://example.com/index.php?journal=journalpath&endpoint=/api/v1/submission
 Administrators can access _some_ endpoints, such as `/contexts`, at a site-wide endpoint that spans all journals.
 
 ```
-https://example.com/_/api/v1/contexts
+https://example.com/index/api/v1/contexts
 ```
 
 ## Authentication


### PR DESCRIPTION
Both "_" and "index" work, and will keep working, at least until 3.6. But as we're going to deprecate the "_", then it makes sense to indicate users to use "index".