### PR TITLE
Corrected Link to Indexing Repositories document

### DIFF
--- a/google-scholar/en/index.md
+++ b/google-scholar/en/index.md
@@ -235,6 +235,6 @@ These redirects would need to be permanent HTTP 301s and not HTTP 302s. For more
 
 1. [Google Scholar inclusion & troubleshooting guidelines](https://scholar.google.com/intl/en/scholar/inclusion.html#indexing)
 
-2. [“Indexing Repositories: Pitfalls & Best Practices” presentation from 2015 Open Repositories conference](https://www.or2015.net/wp-content/uploads/2015/06/or-2015-anurag-google-scholar.pdf) (targeted to repositories, but has good general guidelines for both Scholar & web indexing)
+2. [“Indexing Repositories: Pitfalls & Best Practices” presentation from 2015 Open Repositories conference]([https://www.or2015.net/wp-content/uploads/2015/06/or-2015-anurag-google-scholar.pdf](https://doi.org/10.5281/zenodo.6521981)) (targeted to repositories, but has good general guidelines for both Scholar & web indexing)
 
 3. [PKP Community Forum](https://forum.pkp.sfu.ca/)


### PR DESCRIPTION
Community member brought our attention to the fact that the link for the document was outdated: https://forum.pkp.sfu.ca/t/google-scholar-indexing-issue/91988/35?u=rcgillis

Made correction to updated link