### PR TITLE
Update frontend documentation for 3.5

### DIFF
--- a/dev/documentation/en/frontend-forms.md
+++ b/dev/documentation/en/frontend-forms.md
@@ -1,6 +1,6 @@
 ---
 book: dev-documentation
-version: 3.4
+version: 3.5
 title: Forms - Frontend - Technical Documentation - OJS|OMP|OPS
 ---
 

--- a/dev/documentation/en/frontend-list-panels.md
+++ b/dev/documentation/en/frontend-list-panels.md
@@ -1,10 +1,12 @@
 ---
 book: dev-documentation
-version: 3.4
+version: 3.5
 title: List Panels - Frontend - Technical Documentation - OJS|OMP|OPS
 ---
 
 # List Panels
+> **List Panels are deprecated** and should not be used to build new features. For new listing UI, mostly [Table](https://stable-3_5_0--6555d3db80418bb1681b8b17.chromatic.com/?path=/docs/components-table--docs) component is being used. Good examples are [Reviewer Manager](https://stable-3_5_0--6555d3db80418bb1681b8b17.chromatic.com/?path=/docs/managers-reviewermanager--docs) or [File Manager](https://stable-3_5_0--6555d3db80418bb1681b8b17.chromatic.com/?path=/docs/managers-filemanager--docs) or [Dashboard](https://stable-3_5_0--6555d3db80418bb1681b8b17.chromatic.com/?path=/story/pages-dashboard--init) page.
+{:.warning}
 
 
 Many of the [ListPanel](/dev/ui-library/dev/#/component/ListPanel) components are as complex as a small application. They allow the user to add, edit and delete items, perform faceted searches, navigate through paginated lists, and more.

--- a/dev/documentation/en/frontend-pages.md
+++ b/dev/documentation/en/frontend-pages.md
@@ -1,6 +1,6 @@
 ---
 book: dev-documentation
-version: 3.4
+version: 3.5
 title: Pages - Frontend - Technical Documentation - OJS|OMP|OPS
 ---
 
@@ -67,9 +67,23 @@ Every page template for the editorial backend must use the backend layout to ens
 {/block}
 ```
 
+> **New in 3.5** Starting with version 3.5, page templates go directly to the dedicated Vue.js components. Therefore, the Smarty portion is very minimal. And everything else is implemented directly in Vue.js components. Check out our [Admin UI Technical Roadmap](https://stable-3_5_0--6555d3db80418bb1681b8b17.chromatic.com/?path=/docs/guide-technical-roadmap--docs#vuejs--smarty---vuejs-35) for more details and a dedicated guide for updated [Page architecture](https://stable-3_5_0--6555d3db80418bb1681b8b17.chromatic.com/?path=/docs/guide-page-architecture--docs).
+{:.tip}
+
+```html
+{extends file="layouts/backend.tpl"}
+{block name="page"}
+	<dashboard-page v-bind="pageInitConfig" />
+{/block}
+```
+
 ## Smarty
 
-Page templates are rendered by the [Smarty](https://www.smarty.net/) templating engine. The `TemplateManager` extends the `Smarty` class so any of Smarty's methods, such as `assign`, can be used.
+> **Rendering pages with [Smarty](https://www.smarty.net/) templating engine is deprecated**. Documentation below is still useful when working with existing pages which are still relying on Smarty.
+{:.warning}
+
+
+ The `TemplateManager` extends the `Smarty` class so any of Smarty's methods, such as `assign`, can be used.
 
 Assign variables to a template in the `PageHandler`.
 

--- a/dev/documentation/en/frontend-ui-library.md
+++ b/dev/documentation/en/frontend-ui-library.md
@@ -1,15 +1,17 @@
 ---
 book: dev-documentation
-version: 3.4
+version: 3.5
 title: UI Library - Frontend - Technical Documentation - OJS|OMP|OPS
 ---
 
 # UI Library
 
-> Read and understand the essentials section of the [Vue.js guide](https://vuejs.org/v2/guide/) before continuing.
+> Read and understand the essentials section of the [Vue.js guide](https://vuejs.org/guide/introduction.html) before continuing.
 {:.tip}
 
-The [UI Library](/dev/ui-library/dev) is built with [Vue.js](https://vuejs.org/). It provides reusable components to create consistent, accessible user interfaces for all PKP applications. This chapter describes how to pass data into the root Vue.js component and manage state in the browser.
+
+> **New in 3.5** Detailed [Guide](https://stable-3_5_0--6555d3db80418bb1681b8b17.chromatic.com/?path=/) for the frontend development of the editorial UI is now covered in [Storybook](https://storybook.js.org) along with documentation for our components and composables. Please follow it when building new features. 
+{:.tip}
 
 ## Page Component
 
@@ -22,6 +24,20 @@ The [Page component](/dev/ui-library/dev/#/component/Page) is the root component
 	<badge :is-success="true">Published</badge>
 {/block}
 ```
+
+> **New in 3.5** For new pages in 3.5, the Page component is only responsible for rendering the top bar, navigation, and the root page component for the given page. Once you have that set up, follow [Guide](https://stable-3_5_0--6555d3db80418bb1681b8b17.chromatic.com/?path=/) in the storybook. Example for a dashboard page:
+{:.tip}
+
+```html
+{extends file="layouts/backend.tpl"}
+{block name="page"}
+	<dashboard-page v-bind="pageInitConfig" />
+{/block}
+```
+
+
+> **Mixing Smarty and Vue.js templates is deprecated** and should not be used to build new features. The documentation provided here is for developers who need to modify an existing page using Smarty.
+{:.warning}
 
 Smarty syntax can be mixed with components from the UI Library. The template below shows a badge when a submission is published.
 
@@ -38,6 +54,23 @@ Smarty syntax can be mixed with components from the UI Library. The template bel
 Sometimes the publication status will change before the Smarty template is reloaded. When actions are taken in the browser that change the publication status, we need to show or hide the `<badge>` by using state.
 
 ## State
+
+> **New in 3.5** State is now used only to pass initial configuration to the Vue.js component responsible for rendering the page and managing its own state. Currently used mainly to pass the form configurations, which are still being constructed in PHP. Other data should ideally be fetched from the API.
+Using the following name convention to pass the configuration to the new page:
+{:.tip}
+
+```php
+	$templateMgr->setState([
+		'pageInitConfig' => [
+			'selectRevisionDecisionForm' => $selectRevisionDecisionForm->getConfig(),
+			'selectRevisionRecommendationForm' => $selectRevisionRecommendationForm->getConfig(),
+		]
+	]);
+```
+
+> The documentation below is for developers who need to modify an existing page using Smarty.
+{:.warning}
+
 
 Data that may change after the page is loaded is called state. For example, when an editor publishes or unpublishes a submission the template needs to update to reflect the new submission status.
 

--- a/dev/documentation/en/frontend.md
+++ b/dev/documentation/en/frontend.md
@@ -1,6 +1,6 @@
 ---
 book: dev-documentation
-version: 3.4
+version: 3.5
 title: Frontend - Technical Documentation - OJS|OMP|OPS
 ---
 


### PR DESCRIPTION
This is to update frontend documentation, mainly to make clear whats deprecated and point to the storybook for 3.5 practices.

@ewhanson Hi Erik, could you have a look. I bit struggled to balance between keeping the old docs, which are still relevant for some pages and clearly point of what the current practices are. Let me know if this look ok to you.