### PR TITLE
Fixes some headings in payments-subscriptions, adds front matter

### DIFF
--- a/payments-subscriptions/en/README.md
+++ b/payments-subscriptions/en/README.md
@@ -1,6 +1,9 @@
 ---
+book: Managing Subscriptions and Payments in OJS & OMP
+version: 3.5
 title: 'Managing Subscriptions and Payments in OJS and OMP'
 description: Journals that enable subscriptions or charge fees require some additional configurations. In this chapter you’ll learn how to configure and track payments and manage your subscriptions.
+showPageTOC: true
 ---
 
 ## Introduction 

--- a/payments-subscriptions/en/issue-article-oa.md
+++ b/payments-subscriptions/en/issue-article-oa.md
@@ -1,4 +1,6 @@
 ---
+book: Managing Subscriptions and Payments in OJS & OMP
+version: 3.5
 title: Designate Selected Issues or Articles as Open Access
 showPageTOC: true
 ---

--- a/payments-subscriptions/en/manage-subscriptions.md
+++ b/payments-subscriptions/en/manage-subscriptions.md
@@ -1,9 +1,11 @@
 ---
-title: 
+book: Managing Subscriptions and Payments in OJS & OMP
+version: 3.5
+title: Manage Payments and Subscriptions
 showPageTOC: true
 ---
 
-## Manage Subscriptions {#manage-subscriptions)
+## Manage Subscriptions 
 
 >Note: The information in this guide is applicable to OJS/OMP/OPS versions 3.4 and 3.5. For information on Managing Subscriptions in an earlier version, please refer to the relevant chapter in [Learning OJS 3.3](https://docs.pkp.sfu.ca/learning-ojs/3.3/en/subscriptions) or the appropriate version.
 {:.notice} 

--- a/payments-subscriptions/en/manage-subscriptions.md
+++ b/payments-subscriptions/en/manage-subscriptions.md
@@ -5,7 +5,7 @@ title: Manage Payments and Subscriptions
 showPageTOC: true
 ---
 
-## Manage Subscriptions 
+## Manage Subscriptions {#manage-subscriptions}
 
 >Note: The information in this guide is applicable to OJS/OMP/OPS versions 3.4 and 3.5. For information on Managing Subscriptions in an earlier version, please refer to the relevant chapter in [Learning OJS 3.3](https://docs.pkp.sfu.ca/learning-ojs/3.3/en/subscriptions) or the appropriate version.
 {:.notice} 

--- a/payments-subscriptions/en/payment-settings.md
+++ b/payments-subscriptions/en/payment-settings.md
@@ -1,4 +1,6 @@
 ---
+book: Managing Subscriptions and Payments in OJS & OMP
+version: 3.5
 title: Enable and Configure Payments
 showPageTOC: true
 ---

--- a/payments-subscriptions/en/set-fees.md
+++ b/payments-subscriptions/en/set-fees.md
@@ -1,9 +1,11 @@
 ---
+book: Managing Subscriptions and Payments in OJS & OMP
+version: 3.5
 title: Configure Author, Reader, and Other Fees
 showPageTOC: true
 ---
 
-## Configure Author, Reader, and Other Fees {#set-fees)
+## Configure Author, Reader, and Other Fees {#set-fees}
 
 To set the amounts for different types of fees such as author and reader fees, go to the Payment Types tab of the Payments Menu.
 

--- a/payments-subscriptions/en/sub-info.md
+++ b/payments-subscriptions/en/sub-info.md
@@ -1,4 +1,6 @@
 ---
+book: Managing Subscriptions and Payments in OJS & OMP
+version: 3.5
 title: Display Subscription Information to Readers
 showPageTOC: true
 ---

--- a/payments-subscriptions/en/subscription-policies.md
+++ b/payments-subscriptions/en/subscription-policies.md
@@ -1,4 +1,6 @@
 ---
+book: Managing Subscriptions and Payments in OJS & OMP
+version: 3.5
 title: Configure Subscription Policies
 showPageTOC: true
 ---

--- a/payments-subscriptions/en/subscription-types.md
+++ b/payments-subscriptions/en/subscription-types.md
@@ -1,4 +1,6 @@
 ---
+book: Managing Subscriptions and Payments in OJS & OMP
+version: 3.5
 title: Create Subscription Types
 showPageTOC: true
 ---

--- a/payments-subscriptions/en/track-payments.md
+++ b/payments-subscriptions/en/track-payments.md
@@ -1,4 +1,6 @@
 ---
+book: Managing Subscriptions and Payments in OJS & OMP
+version: 3.5
 title: Track Payment Notifications
 showPageTOC: true
 ---


### PR DESCRIPTION
Apparently I am not super-leet because there were a couple of heading slugs that I closed with a parenth instead of a curly brace. This PR corrects that and adds the book name and version to the front matter of chapter files. 