### PR TITLE
Add Crowdin actions

### DIFF
--- a/.github/workflows/crowdin/cron.yml
+++ b/.github/workflows/crowdin/cron.yml
@@ -1,0 +1,35 @@
+name: Crowdin upstream translations sync
+on:
+  schedule:
+    - cron: '0 */12 * * *' # Every 12 hours
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync Crowdin translations
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: 'false'
+          upload_translations: 'false'
+
+          download_translations: 'true'
+          localization_branch_name: 'l10n_crowdin_action'
+          create_pull_request: 'true'
+          push_translations: 'true'
+          pull_request_title: 'New Crowdin translations by GitHub Action'
+          pull_request_body: 'New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)'
+          pull_request_base_branch_name: 'main'
+          base_url: 'https://pkp-documentation.crowdin.com/api/v2'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/crowdin/crowdin.yml
+++ b/.github/workflows/crowdin/crowdin.yml
@@ -1,0 +1,35 @@
+name: Crowdin source file sync
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync Crowdin translations
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: 'true'
+          upload_translations: 'false'
+
+          download_translations: 'true'
+          localization_branch_name: 'l10n_crowdin_action'
+          create_pull_request: 'true'
+          push_translations: 'true'
+          pull_request_title: 'New Crowdin translations by GitHub Action'
+          pull_request_body: 'New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)'
+          pull_request_base_branch_name: 'main'
+          base_url: 'https://pkp-documentation.crowdin.com/api/v2'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,14 @@
+"project_id_env": "CROWDIN_PROJECT_ID"
+"api_token_env": "CROWDIN_PERSONAL_TOKEN"
+
 files:
   - source: /**/en/*.md
     translation: /**/%two_letters_code%/%original_file_name%
+    ignore:
+      - /coalition-publica
+      - /crossref-ojs2-manual
+      - /learning-ojs-2
+      - /learning-ojs/3.1
+      - /learning-ojs/3.2
+      - /ojs-2-technical-reference
+      - /using-paypal-for-ojs-and-ocs


### PR DESCRIPTION
Includes two sets of Github actions to sync translations from Crowdin.

- On push to `main`, source files will be pushed to Crowdin and translations will be downloaded with PRs made for any new translations.
- Every 12 hours, translations will be downloaded with PRs made for any new translations.