### PR TITLE
pkp/pkp-docs#1362 A11Y - Footer links and text with low contrast ratio

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -9,6 +9,8 @@ $text-on-dark: #fff;
 $link: #0073A8;
 $link-hover: lighten($link, 10%);
 
+$link-footer: #D5D7D7;
+
 $help: #1CA683;
 $tech: #e08914;
 $warning: #e0143f;

--- a/_sass/components/siteFooter.scss
+++ b/_sass/components/siteFooter.scss
@@ -145,7 +145,7 @@
             margin-bottom: 40px;
         }
         p {
-            color: #9A9C9F;
+            color: $link-footer;
             font-family: Roboto;
             font-size: 14px;
             font-style: normal;
@@ -165,7 +165,7 @@
         display: flex;
         align-items: center;
         .terms-text {
-            color: #9A9C9F;
+            color: $link-footer;
             font-family: Barlow Condensed;
             font-size: 14px;
             font-style: normal;
@@ -173,7 +173,7 @@
             line-height: 135%;
             margin-right: 15px;
             a {
-                color: #9A9C9F;
+                color: $link-footer;
                 text-decoration: underline;
                 &:hover {
                     color: #CC0633;
@@ -181,7 +181,7 @@
             }
         }
         .copyright-text {
-            color: #9A9C9F;
+            color: $link-footer;
             font-family: Roboto;
             font-size: 14px;
             font-style: normal;
@@ -194,7 +194,7 @@
                 margin-right: 2px;
             }
             a {
-                color: #9A9C9F;
+                color: $link-footer;
                 text-decoration: underline;
                 margin-left: 12px;
                 &:hover {
@@ -205,19 +205,19 @@
         .footer-copyright-separator {
             font-family: Roboto;
             font-weight: normal;
-            color: #9A9C9F;
+            color: $link-footer;
             margin: 0 15px;
         }
         .ab-link {
             margin-left: 0px;
-            color: #9A9C9F;
+            color: $link-footer;
             font-family: Roboto;
             font-size: 14px;
             font-style: normal;
             font-weight: 400;
             line-height: 135%;
             a {
-                color: #9A9C9F;
+                color: $link-footer;
                 text-decoration: underline;
                 &:hover {
                     color: #CC0633;


### PR DESCRIPTION
Fixing the contrast ration for links and texts in the footer section of all pages.