### PR TITLE
pkpdocs#1388 A11Y - Heading level 1 missing in the homepageA11Y

### DIFF
--- a/_includes/hub/header.html
+++ b/_includes/hub/header.html
@@ -1,5 +1,5 @@
 <div class="siteHeader siteHeader--hub">
-	<h1 class="-screenReader" id="search-title">{{ page.title }}</h1>
+	<h1 class="-screenReader">{{ page.title }}</h1>
 	<a class="siteHeader__logo" href="/">
 		<img src="/img/logo-on-white.png" alt="{{ site.data.site.logoAltText }}" class="siteHeader__logoImage">
 	</a>


### PR DESCRIPTION
Adding a visually hidden Heading level 1 (`H1` tag) in the homepage.