### PR TITLE
pkp/pkp-docs#1401 A11Y - Footer logo image alt text and link

### DIFF
--- a/_includes/hub/footer.html
+++ b/_includes/hub/footer.html
@@ -33,8 +33,8 @@
 				</nav>
 			{% endif %}
 			<div class="siteFooter__logo">
-				<a href="https://pkp.sfu.ca">
-					<img src="/img/logo-on-grey.png" alt="Public Knowledge Project">
+				<a href="/">
+					<img src="/img/logo-on-grey.png" alt="Go to the PKP Docs homepage">
 				</a>
 				<p>The Public Knowledge Project is a Core Facility of Simon Fraser University</p>
                 <p>888 University Drive, Burnaby, B.C., Canada V5A 1S6</p>


### PR DESCRIPTION
Fix the `alt` text to announce where the link is pointing (PKP Docs homepage) and update the link to the correct target.