### PR TITLE
pkp/pkp-docs#14143 A11Y - Creative Commons license link and label

### DIFF
--- a/_includes/hub/footer.html
+++ b/_includes/hub/footer.html
@@ -42,7 +42,7 @@
 			</div>
 		</div>
 		<div class="siteFooter__bottom">
-			<p class="footer-copyright"><span class="terms-text"><a href="https://www.sfu.ca/contact/terms-conditions.html" target="_blank">TERMS & CONDITIONS</a> &copy; SIMON FRASER UNIVERSITY.</span><span class="copyright-text"><img src="/img/creativecommons.svg" alt="Creative Commons logo" /><img src="/img/attribution.svg" alt="Attribution icon" /><a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">CC BY 4.0<span class="-screenReader"> - Attribution 4.0 International </span></a></span><span class="footer-copyright-separator"></span></p>
+			<p class="footer-copyright"><span class="terms-text"><a href="https://www.sfu.ca/contact/terms-conditions.html" target="_blank">TERMS & CONDITIONS</a> &copy; SIMON FRASER UNIVERSITY.</span><span class="copyright-text"><img src="/img/creativecommons.svg" alt="Creative Commons logo" /><img src="/img/attribution.svg" alt="Attribution icon" /><a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">CC BY 4.0<span class="-screenReader"> - Attribution 4.0 International </span></a></span></p>
 		</div>
 	</div>
 </footer>


### PR DESCRIPTION
Updating the CC version in the footer, and adding a visually hidden label to be announced by screenreaders. 